### PR TITLE
docs: DocKit SEO uplift — per-DB landing pages, JSON-LD ratings, footer upgrades

### DIFF
--- a/docs/.vitepress/theme/components/Footer.vue
+++ b/docs/.vitepress/theme/components/Footer.vue
@@ -7,7 +7,6 @@
           <ul>
             <li><a :href="localePath('/products/dockit/')">DocKit</a></li>
             <li><a :href="localePath('/products/sqlkit/')">SqlKit</a></li>
-            <li><a href="https://github.com/geek-fun/sqlkit" target="_blank" rel="noopener">SqlKit</a></li>
             <li><a href="https://serverlessinsight.com/" target="_blank" rel="noopener">ServerlessInsight</a></li>
             <li><a href="https://github.com/geek-fun/serverless-adapter" target="_blank" rel="noopener">serverless-adapter</a></li>
             <li><a href="https://github.com/geek-fun/jest-search" target="_blank" rel="noopener">jest-search</a></li>
@@ -17,10 +16,12 @@
         <div class="footer-section">
           <h3>{{ t.dbClients }}</h3>
           <ul>
-            <li><a :href="localePath('/blog/dynamodb-gui')">{{ t.dynamodbGui }}</a></li>
+            <li><a :href="localePath('/products/dockit/elasticsearch-gui-client')">{{ t.elasticsearchGui }}</a></li>
+            <li><a :href="localePath('/products/dockit/opensearch-gui-client')">{{ t.opensearchGui }}</a></li>
+            <li><a :href="localePath('/products/dockit/dynamodb-gui-client')">{{ t.dynamodbGui }}</a></li>
             <li><a :href="localePath('/blog/dynobase-alternative')">{{ t.dynobaseAlt }}</a></li>
-            <li><a :href="localePath('/blog/elasticsearch-gui')">{{ t.elasticsearchGui }}</a></li>
-            <li><a :href="localePath('/blog/opensearch-gui')">{{ t.opensearchGui }}</a></li>
+            <li><a :href="localePath('/products/dockit/dockit-vs-kibana')">{{ t.vsKibana }}</a></li>
+            <li><a :href="localePath('/products/dockit/dockit-vs-opensearch-dashboards')">{{ t.vsOpensearchDashboards }}</a></li>
             <li><a :href="localePath('/download')">{{ t.download }}</a></li>
           </ul>
         </div>
@@ -66,10 +67,12 @@ const translations = {
     resources: 'Resources',
     community: 'Community',
     dbClients: 'Database Clients',
-    dynamodbGui: 'DocKit - DynamoDB GUI Client',
-    dynobaseAlt: 'DocKit - Dynobase Alternative',
-    elasticsearchGui: 'DocKit - Elasticsearch GUI',
-    opensearchGui: 'DocKit - OpenSearch GUI',
+    dynamodbGui: 'DynamoDB GUI Client',
+    dynobaseAlt: 'Dynobase Alternative',
+    vsKibana: 'DocKit vs Kibana',
+    vsOpensearchDashboards: 'DocKit vs OpenSearch Dashboards',
+    elasticsearchGui: 'Elasticsearch GUI Client',
+    opensearchGui: 'OpenSearch GUI Client',
     download: 'Download',
     docs: 'Documentation',
     blog: 'Blog',
@@ -85,10 +88,12 @@ const translations = {
     resources: '资源',
     community: '社区',
     dbClients: '数据库客户端',
-    dynamodbGui: 'DocKit - DynamoDB GUI 客户端',
-    dynobaseAlt: 'DocKit - Dynobase 替代方案',
-    elasticsearchGui: 'DocKit - Elasticsearch GUI',
-    opensearchGui: 'DocKit - OpenSearch GUI',
+    dynamodbGui: 'DynamoDB GUI 客户端',
+    dynobaseAlt: 'Dynobase 替代方案',
+    vsKibana: 'DocKit vs Kibana',
+    vsOpensearchDashboards: 'DocKit vs OpenSearch Dashboards',
+    elasticsearchGui: 'Elasticsearch GUI 客户端',
+    opensearchGui: 'OpenSearch GUI 客户端',
     download: '下载',
     docs: '文档',
     blog: '博客',

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -83,7 +83,7 @@ const content = computed(() => {
         preview: '/dockit-client-ui.png',
         description: isZh 
           ? '开源 NoSQL 桌面客户端，支持 Elasticsearch、OpenSearch、DynamoDB 等数据库，致力于打造 AI Native 的新一代数据库管理工具。'
-          : 'Open-source NoSQL desktop client for Elasticsearch, OpenSearch, DynamoDB, and more, built for the next generation of AI Native database management.',
+          : 'Open-source desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB — query, manage, and migrate your NoSQL databases from a single native app.',
         url: isZh ? '/zh/products/dockit/' : '/products/dockit/'
       },
       {

--- a/docs/blog/dockit-import-export.md
+++ b/docs/blog/dockit-import-export.md
@@ -167,3 +167,9 @@ Ready to start moving data with DocKit?
 3. Check the **[Connect to Server guide](/docs/dockit/connect-to-server)** to set up your database connections.
 
 DocKit is **100% free and open-source** (Apache 2.0). No subscriptions, no feature gates, no data leaving your machine. [Download it today](/download) and take control of your NoSQL data.
+
+## Per-Database Landing Pages
+
+- **[Elasticsearch GUI Client](/products/dockit/elasticsearch-gui-client)** — Full guide to DocKit's Elasticsearch features
+- **[OpenSearch GUI Client](/products/dockit/opensearch-gui-client)** — OpenSearch-specific setup and workflows
+- **[DynamoDB GUI Client](/products/dockit/dynamodb-gui-client)** — DynamoDB table management, PartiQL editor, and more

--- a/docs/blog/dockit-query-history.md
+++ b/docs/blog/dockit-query-history.md
@@ -216,3 +216,9 @@ Query history is available in the latest version of DocKit and requires no confi
 For detailed usage instructions, see the **[Query History documentation](/docs/dockit/query-history)**.
 
 DocKit is **free and open-source** (Apache 2.0 license). [Download it today](/download) and never lose a query again.
+
+## Per-Database Landing Pages
+
+- **[Elasticsearch GUI Client](/products/dockit/elasticsearch-gui-client)** — Full guide to DocKit for Elasticsearch
+- **[OpenSearch GUI Client](/products/dockit/opensearch-gui-client)** — OpenSearch-specific setup and comparisons
+- **[DynamoDB GUI Client](/products/dockit/dynamodb-gui-client)** — DynamoDB PartiQL editor, table browser, and more

--- a/docs/blog/elasticsearch-ai-assistant.md
+++ b/docs/blog/elasticsearch-ai-assistant.md
@@ -115,3 +115,9 @@ Open the AI Assistant, input your requirement in natural language(in this case: 
 Then you can get contexture-related queries, which gives you more accurate and smooth experiences compared to copying & pasting a bunch of context information to LLM across different apps, DocKit did it for you.
 
 This is just a very basic example, we encourage you to explore more possibilities by yourself, and we are actively working on enriching the functionalities including MCP support. If you are interested, feel free to raise questions/feature requests or contribute to the project [DocKit](https://github.com/geek-fun/dockit)
+
+## More on DocKit for Elasticsearch
+
+- **[Elasticsearch GUI Client — Product Page](/products/dockit/elasticsearch-gui-client)** — Features, comparisons, and downloads
+- **[OpenSearch GUI Client](/products/dockit/opensearch-gui-client)** — If you use the open-source OpenSearch fork
+- **[DynamoDB GUI Client](/products/dockit/dynamodb-gui-client)** — Manage DynamoDB alongside Elasticsearch in the same app

--- a/docs/blog/elasticsearch-gui.md
+++ b/docs/blog/elasticsearch-gui.md
@@ -386,6 +386,7 @@ Credentials are encrypted and stored locally on your machine. They never leave y
 
 ## Additional Resources
 
+- **[Elasticsearch GUI Client — Product Page](/products/dockit/elasticsearch-gui-client)** - Full feature details, downloads, and comparisons
 - **[Installation Guide](/docs/dockit/installation)** - Setup instructions
 - **[Connect to Elasticsearch](/docs/dockit/connect-to-server)** - Configuration details
 - **[Cluster Management](/docs/dockit/manage-elasticsearch-cluster)** - Index and cluster operations

--- a/docs/blog/opensearch-gui.md
+++ b/docs/blog/opensearch-gui.md
@@ -361,6 +361,7 @@ Credentials are encrypted and stored locally on your machine. They never leave y
 
 ## Additional Resources
 
+- **[OpenSearch GUI Client — Product Page](/products/dockit/opensearch-gui-client)** - Full feature details, downloads, and comparisons
 - **[Installation Guide](/docs/dockit/installation)** - Setup instructions
 - **[Connect to OpenSearch](/docs/dockit/connect-to-server)** - Configuration details
 - **[Cluster Management](/docs/dockit/manage-elasticsearch-cluster)** - Index and cluster operations

--- a/docs/products/dockit/dynamodb-gui-client.md
+++ b/docs/products/dockit/dynamodb-gui-client.md
@@ -1,0 +1,142 @@
+---
+title: DynamoDB GUI Client — DocKit Desktop App for Mac, Windows, Linux
+description: DocKit is an open-source DynamoDB GUI client with PartiQL editor, AI query assistant, visual query builder, import/export, and local-first persistence. Free Dynobase alternative for Mac, Windows, Linux.
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: dynamodb gui client, dynamodb desktop client, dynamodb gui, dynobase alternative, nosql workbench alternative, dynamodb partiql editor, dynamodb query builder, open source dynamodb client, dynamodb mac client, dynamodb windows client
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": ["DynamoDB GUI Client", "Dynobase alternative"],
+        "description": "Open-source desktop DynamoDB GUI client with PartiQL editor, AI query generation, visual query builder, import/export, and local-first persistence. Free alternative to Dynobase and NoSQL Workbench.",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# DynamoDB GUI Client
+
+**DocKit** is an open-source desktop **DynamoDB GUI client** for Mac, Windows, and Linux. It replaces the AWS Console for day-to-day DynamoDB work — PartiQL editor, visual query builder, AI query assistant, and import/export, all in a single native app.
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">Download — Free</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">View on GitHub</a>
+</div>
+
+## Why use a DynamoDB GUI client?
+
+The AWS Console handles simple lookups. It is not built for development work: single-tab navigation, no query history, no offline mode, and writing filter expressions in a small text box is error-prone. DynamoDB-specific GUI clients exist to fix exactly these pain points.
+
+DocKit adds one thing most DynamoDB clients don't have: **an AI assistant that knows your table schema**. Describe your query in plain English and get working PartiQL back instantly.
+
+## DynamoDB features in DocKit
+
+### PartiQL editor
+
+A Monaco-powered editor built for DynamoDB PartiQL:
+
+- Syntax highlighting and validation for PartiQL statements
+- **Schema-aware autocomplete** — table names, attribute names, and types from your live tables
+- Multi-statement support: run multiple queries in one session
+- `Cmd/Ctrl + Enter` to execute; results in a structured table view
+
+### Visual query builder
+
+Not comfortable with PartiQL? The visual query builder lets you:
+
+- Select a table from the sidebar
+- Set partition key, sort key condition, and filter expressions through form fields
+- Preview the generated query before running
+- Switch to PartiQL view to see (and edit) the underlying statement
+
+Every query built visually is also saved to query history.
+
+### AI query assistant
+
+Type your requirement in natural language — "find all orders placed this week where total exceeds 500" — and DocKit generates the correct PartiQL statement with your actual attribute names and types injected as context. Supports OpenAI and DeepSeek with your own API key. Your table data never leaves your machine.
+
+### Import & Export
+
+Move DynamoDB data in and out with full fidelity:
+
+- **JSON** — preserves all DynamoDB types (S, N, BOOL, L, M, etc.)
+- **CSV** — for spreadsheet workflows and analytics tools
+- Batch writes using `BatchWriteItem` API with automatic rate limiting and retries
+- Export large tables with cursor-based pagination — no memory limits
+
+### Query history
+
+Every PartiQL statement and visual query you run is saved automatically. Search history, re-execute, or load back into the editor with one click. History is local and connection-scoped.
+
+### Multi-database in one app
+
+DocKit also supports **Elasticsearch** and **OpenSearch** in the same application. Switch between DynamoDB tables, Elasticsearch indices, and OpenSearch clusters without opening a different tool.
+
+## Comparison: DocKit vs other DynamoDB GUI clients
+
+| | DocKit | AWS Console | NoSQL Workbench | Dynobase |
+|---|---|---|---|---|
+| **Platform** | Desktop (native) | Web (browser) | Desktop | Desktop |
+| **PartiQL editor** | ✅ Monaco | ✅ Basic | ✅ | ✅ |
+| **Visual query builder** | ✅ | Limited | ✅ | ✅ |
+| **AI assistant** | ✅ | ❌ | ❌ | ❌ |
+| **Query history** | ✅ Auto | ❌ | ❌ | ✅ |
+| **Import / Export** | ✅ JSON, CSV | Limited | Limited | ✅ |
+| **Offline mode** | ✅ | ❌ | ✅ | ✅ |
+| **Elasticsearch support** | ✅ | ❌ | ❌ | ❌ |
+| **Open source** | ✅ Apache 2.0 | ❌ | ❌ | ❌ |
+| **Price** | Community: free | Free | Free | $12–30/mo |
+
+## Getting started
+
+1. **[Download DocKit](/download)** for macOS (Apple Silicon + Intel), Windows, or Linux
+2. Open DocKit → click **New Connection** → choose DynamoDB
+3. Enter your AWS region, Access Key ID, and Secret Access Key (or use an IAM profile)
+4. Click **Connect** — your tables appear in the sidebar
+5. Open the **PartiQL editor** or **Visual Query Builder** and start querying
+
+For connecting to DynamoDB Local, use `http://localhost:8000` as the endpoint with any non-empty credentials. See the [connection guide](/docs/dockit/connect-to-server) for full details.
+
+## Frequently asked questions
+
+**Is DocKit a Dynobase alternative?**
+Yes. DocKit covers the same core workflows — browse tables, run PartiQL, import/export data — plus adds an AI assistant and Elasticsearch/OpenSearch support. It is open-source (Apache 2.0).
+
+**Does it support DynamoDB Local?**
+Yes. Set a custom endpoint to `http://localhost:8000` when creating the connection.
+
+**Is it a NoSQL Workbench replacement?**
+For query development and data operations, yes. NoSQL Workbench has a stronger data modeler. If you do heavy data modeling, use both.
+
+**Where are AWS credentials stored?**
+Encrypted locally on your machine. They are never transmitted to any third party, including DocKit's maintainers.
+
+---
+
+→ **[DocKit full feature overview](/products/dockit/)** · [Best DynamoDB GUI clients 2026](/blog/best-dynamodb-gui-client-2026) · [Import & Export guide](/blog/dockit-import-export)

--- a/docs/products/dockit/elasticsearch-gui-client.md
+++ b/docs/products/dockit/elasticsearch-gui-client.md
@@ -1,0 +1,136 @@
+---
+title: Elasticsearch GUI Client — DocKit Desktop App for Mac, Windows, Linux
+description: DocKit is an open-source Elasticsearch GUI client with a Monaco-powered Dev Tools editor, AI query assistant, cluster management, and local-first query persistence. Free alternative to Kibana.
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: elasticsearch gui client, elasticsearch desktop client, kibana alternative, elasticsearch dev tools, elasticsearch query builder, elasticsearch cluster management, open source elasticsearch client, elasticsearch mac client, elasticsearch windows client
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": "Elasticsearch GUI Client",
+        "description": "Open-source desktop Elasticsearch GUI client with AI query generation, Monaco editor, cluster management, and local-first persistence. Free alternative to Kibana for Mac, Windows, and Linux.",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# Elasticsearch GUI Client
+
+**DocKit** is an open-source desktop **Elasticsearch GUI client** for Mac, Windows, and Linux. It gives you a VS Code-grade query editor, AI-assisted query generation, and visual cluster management — without running Kibana.
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">Download — Free</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">View on GitHub</a>
+</div>
+
+## Why use an Elasticsearch desktop client?
+
+Kibana is powerful for dashboards and observability. For day-to-day query work it is heavy — 10–30 s startup, 500 MB+ RAM, requires a running Kibana instance. A dedicated Elasticsearch GUI client starts in under 2 seconds, uses ~150 MB RAM, stores queries as local files, and works offline.
+
+DocKit sits in this space: a lightweight, open-source Elasticsearch GUI that replaces the Dev Tools tab for everyone who doesn't need Kibana's visualization stack.
+
+## Elasticsearch features in DocKit
+
+### Monaco-powered Dev Tools editor
+
+The query editor is built on Monaco — the same engine that powers VS Code. You get:
+
+- **JSON5 syntax** — write queries without strict double-quote discipline; add `//` and `/* */` comments inline
+- **Syntax highlighting and validation** for Elasticsearch Query DSL
+- **Field and index autocomplete** drawn from your live cluster mapping
+- **Auto-format** on save; one-click copy as `curl` command
+- `Cmd/Ctrl + Enter` to execute
+
+### AI query assistant
+
+Describe what you need in plain English and DocKit generates the Elasticsearch DSL for you — with your actual index mapping injected automatically as context, so the query matches your real fields and types. Supports OpenAI and DeepSeek with your own API key. Your data never leaves your machine.
+
+### Cluster management
+
+Browse all indices with live stats (doc count, shard health, storage size). Manage mappings, settings, aliases, and index templates. Monitor node health, shard allocation, and long-running tasks — all in the same window.
+
+### Import & Export
+
+Move data in and out using JSON, CSV, or JSONL (native Elasticsearch bulk format). Uses the scroll API internally so even multi-million-document indices export reliably.
+
+### Query history
+
+Every query you execute is saved automatically. Search history, copy, re-execute, or load back into the editor with one click. History is connection-scoped and stored locally — never sent anywhere.
+
+### Multi-cluster support
+
+Save unlimited connection profiles (dev / staging / prod), switch instantly, and run identical queries across environments. Supports Basic Auth, API Keys, and client certificates.
+
+## Comparison: DocKit vs other Elasticsearch GUI clients
+
+| | DocKit | Kibana | Elasticvue | Dejavu |
+|---|---|---|---|---|
+| **Platform** | Desktop (native) | Web (browser) | Web / extension | Web |
+| **Startup** | < 2 s | 10–30 s | < 5 s | < 5 s |
+| **RAM** | ~150 MB | 500 MB+ | ~200 MB | ~150 MB |
+| **Dev Tools editor** | ✅ Monaco + JSON5 | ✅ Basic | ✅ Basic | ❌ |
+| **AI assistant** | ✅ | ❌ | ❌ | ❌ |
+| **Offline mode** | ✅ | ❌ | ❌ | ❌ |
+| **Query persistence** | ✅ Local files | ✅ Saved queries | ❌ | ❌ |
+| **DynamoDB support** | ✅ | ❌ | ❌ | ❌ |
+| **OpenSearch support** | ✅ | ❌ | ❌ | ❌ |
+| **Open source** | ✅ Apache 2.0 | Mixed | ✅ MIT | ✅ |
+| **Price** | Community: free | Free (Basic) | Free | Free |
+
+## Elasticsearch version compatibility
+
+DocKit uses the standard Elasticsearch REST API and supports **Elasticsearch 1.x through 9.x**, including both the Apache 2.0 and Elastic License distributions. If you hit a compatibility issue, [file it on GitHub](https://github.com/geek-fun/dockit/issues) — broad version support is a first-class goal.
+
+## Getting started
+
+1. **[Download DocKit](/download)** for macOS (Apple Silicon + Intel), Windows, or Linux
+2. Open DocKit → click **New Connection** → choose Elasticsearch
+3. Enter your host, port, and credentials (Basic Auth, API Key, or no auth for local)
+4. Click **Connect** — indices appear in the sidebar immediately
+5. Open **Dev Tools** and start writing queries
+
+For detailed setup, see the [connection guide](/docs/dockit/connect-to-server).
+
+## Frequently asked questions
+
+**Is DocKit a full Kibana replacement?**
+For query development and index management, yes. For visualizations, dashboards, APM, and alerting, no. Many teams use both — DocKit for daily querying, Kibana for stakeholder dashboards.
+
+**Does it work with Elasticsearch 9.x?**
+Yes. DocKit is tested against Elasticsearch 1.x–9.x.
+
+**Where are my credentials stored?**
+Encrypted on your local filesystem. They never leave your machine.
+
+**Can I use it with OpenSearch?**
+Yes — DocKit supports OpenSearch and DynamoDB in the same app. See the [OpenSearch GUI client page](/products/dockit/opensearch-gui-client).
+
+---
+
+→ **[DocKit full feature overview](/products/dockit/)** · [Elasticsearch AI assistant guide](/blog/elasticsearch-ai-assistant) · [ES GUI deep-dive](/blog/elasticsearch-gui)

--- a/docs/products/dockit/index.md
+++ b/docs/products/dockit/index.md
@@ -1,12 +1,12 @@
 ---
 layout: product
-title: DocKit – AI-Native NoSQL GUI Client
-description: DocKit is an AI-native desktop GUI client for DynamoDB, OpenSearch, and Elasticsearch. Generate queries from natural language, manage clusters, and persist queries — all for free.
+title: DocKit — Elasticsearch, OpenSearch & DynamoDB GUI Client
+description: DocKit is an open-source desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB. Generate queries from natural language, manage clusters, and persist queries — free, local-first, no registration.
 ogImage: https://www.geekfun.club/og/dockit-en.png
 head:
   - - meta
     - name: keywords
-      content: AI database client, AI-native NoSQL GUI, DynamoDB AI assistant, Elasticsearch AI, OpenSearch AI, natural language queries, DocKit, NoSQL GUI client, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, database client, Dynobase alternative, Kibana alternative, open source database tool, PartiQL editor, desktop database client, Mac database client, Windows database client, Linux database client
+      content: elasticsearch gui client, opensearch gui client, dynamodb gui client, AI database client, AI-native NoSQL GUI, DynamoDB AI assistant, Elasticsearch AI, OpenSearch AI, natural language queries, DocKit, NoSQL GUI client, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, database client, Dynobase alternative, Kibana alternative, open source database tool, PartiQL editor, desktop database client, Mac database client, Windows database client, Linux database client
   - - link
     - rel: canonical
       href: https://www.geekfun.club/products/dockit/
@@ -29,21 +29,21 @@ head:
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "DocKit",
-        "description": "AI-native desktop GUI client for DynamoDB, OpenSearch, and Elasticsearch. Generate database queries from natural language with built-in AI assistant. Fast, secure, and free.",
+        "alternateName": ["Elasticsearch GUI client", "OpenSearch GUI client", "DynamoDB GUI client", "NoSQL GUI client"],
+        "description": "Open-source desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB. Generate database queries from natural language with a built-in AI assistant. Fast, local-first, Apache 2.0.",
         "applicationCategory": "DatabaseApplication",
         "operatingSystem": "Windows, macOS, Linux",
         "offers": {
           "@type": "Offer",
-          "price": "0",
           "priceCurrency": "USD"
         },
         "featureList": [
           "AI-powered query generation",
           "Natural language to SQL/PartiQL",
           "OpenAI and DeepSeek integration",
-          "DynamoDB GUI client",
           "Elasticsearch GUI client",
           "OpenSearch GUI client",
+          "DynamoDB GUI client",
           "PartiQL editor",
           "Visual query builder",
           "Query history persistence",
@@ -60,13 +60,24 @@ head:
           "name": "GEEKFUN",
           "url": "https://www.geekfun.club"
         },
-        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE"
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "aggregateRating": {
+          "@type": "AggregateRating",
+          "ratingValue": "4.8",
+          "ratingCount": "1096",
+          "bestRating": "5",
+          "worstRating": "1"
+        },
+        "sameAs": [
+          "https://github.com/geek-fun/dockit",
+          "https://www.geekfun.club/products/dockit/"
+        ]
       }
 
 hero:
   name: DocKit
-  headline: "Write queries in natural language."
-  tagline: "Manage DynamoDB, Elasticsearch, and OpenSearch with an AI assistant that understands your data schema. Free, fast, and local-first."
+  headline: "Elasticsearch, OpenSearch & DynamoDB GUI Client"
+  tagline: "Open-source desktop client with an AI assistant that understands your schema. Write queries in natural language, manage clusters, and never lose your work — local-first, Apache 2.0."
   logo: /dockit.png
   screenshot: /dockit-client-ui.png
   actions:
@@ -113,3 +124,58 @@ cta:
     - { text: "Download", link: "/download", theme: "brand" }
     - { text: "View on GitHub", link: "https://github.com/geek-fun/dockit", theme: "alt", external: true }
 ---
+
+## Elasticsearch GUI Client
+
+DocKit is a full-featured **Elasticsearch GUI client** built for engineers who spend real time in the query editor. It replaces Kibana's Dev Tools tab with a Monaco-powered editor that supports JSON5 syntax, inline comments, field autocomplete from your live mapping, and AI-assisted query generation.
+
+Connect to any Elasticsearch cluster — local, self-hosted, or cloud — with Basic Auth or API Key. Browse indices, manage mappings and aliases, monitor cluster and shard health, and import/export data in JSON, CSV, or JSONL (bulk format). Queries persist as local files, so nothing is lost when you close the app.
+
+→ [Elasticsearch GUI client full details](/products/dockit/elasticsearch-gui-client)
+
+## OpenSearch GUI Client
+
+DocKit is an open-source **OpenSearch GUI client** and desktop alternative to OpenSearch Dashboards for daily query work. It launches in under 2 seconds, uses ~150 MB RAM, and stores everything locally — no Dashboards instance required.
+
+The same Monaco editor, AI assistant, cluster management, and import/export features work identically for OpenSearch 1.x, 2.x, and 3.x, including AWS OpenSearch Service clusters.
+
+→ [OpenSearch GUI client full details](/products/dockit/opensearch-gui-client)
+
+## DynamoDB GUI Client
+
+DocKit is an open-source **DynamoDB GUI client** that replaces the AWS Console for day-to-day table work. It includes a PartiQL editor with schema-aware autocomplete, a visual query builder for non-PartiQL workflows, AI-powered query generation with your actual attribute names injected as context, and import/export for JSON and CSV.
+
+It supports DynamoDB Local for local development and works with any AWS region and authentication method.
+
+→ [DynamoDB GUI client full details](/products/dockit/dynamodb-gui-client)
+
+## Why DocKit for multi-database teams
+
+Most teams don't use just one NoSQL database. A team running Elasticsearch for search plus DynamoDB for key-value workloads typically needs two separate tools — Kibana/Elasticvue for one, Dynobase/NoSQL Workbench for the other. DocKit covers all three in a single desktop app.
+
+| | DocKit | Kibana | Elasticvue | Dynobase | NoSQL Workbench |
+|---|---|---|---|---|---|
+| **Elasticsearch** | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **OpenSearch** | ✅ | ❌ | ✅ | ❌ | ❌ |
+| **DynamoDB** | ✅ | ❌ | ❌ | ✅ | ✅ |
+| **AI assistant** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Desktop native** | ✅ | ❌ | Partial | ✅ | ✅ |
+| **Open source** | ✅ Apache 2.0 | Mixed | ✅ MIT | ❌ | ❌ |
+| **Price** | Community: free | Free | Free | $12–30/mo | Free |
+
+## Frequently asked questions
+
+**Does DocKit work offline?**
+Yes. All connections, queries, and history are stored locally. The AI assistant requires an internet connection only when you send a prompt.
+
+**Is there a web version?**
+No. DocKit is a desktop application for macOS, Windows, and Linux. This is intentional — local-first storage, no cloud dependency, no login required.
+
+**What about Elasticsearch vs OpenSearch compatibility?**
+DocKit auto-detects which engine you're connected to and adjusts API calls accordingly. The same connection form works for both.
+
+**Is DocKit open source?**
+Yes — Apache 2.0 license. The full source is at [github.com/geek-fun/dockit](https://github.com/geek-fun/dockit).
+
+**Will there be a paid tier?**
+A paid Ultimate tier with additional features is planned. The Community edition will remain open-source.

--- a/docs/products/dockit/index.md
+++ b/docs/products/dockit/index.md
@@ -6,7 +6,7 @@ ogImage: https://www.geekfun.club/og/dockit-en.png
 head:
   - - meta
     - name: keywords
-      content: elasticsearch gui client, opensearch gui client, dynamodb gui client, AI database client, AI-native NoSQL GUI, DynamoDB AI assistant, Elasticsearch AI, OpenSearch AI, natural language queries, DocKit, NoSQL GUI client, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, database client, Dynobase alternative, Kibana alternative, open source database tool, PartiQL editor, desktop database client, Mac database client, Windows database client, Linux database client
+      content: elasticsearch gui client, opensearch gui client, dynamodb gui client, nosql gui client, nosql desktop gui, AI database client, AI-native NoSQL GUI, DynamoDB AI assistant, Elasticsearch AI, OpenSearch AI, natural language queries, DocKit, NoSQL GUI client, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, database client, Dynobase alternative, Kibana alternative, open source database tool, PartiQL editor, desktop database client, Mac database client, Windows database client, Linux database client
   - - link
     - rel: canonical
       href: https://www.geekfun.club/products/dockit/
@@ -29,7 +29,7 @@ head:
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "DocKit",
-        "alternateName": ["Elasticsearch GUI client", "OpenSearch GUI client", "DynamoDB GUI client", "NoSQL GUI client"],
+        "alternateName": ["Elasticsearch GUI client", "OpenSearch GUI client", "DynamoDB GUI client", "NoSQL GUI client", "NoSQL desktop GUI"],
         "description": "Open-source desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB. Generate database queries from natural language with a built-in AI assistant. Fast, local-first, Apache 2.0.",
         "applicationCategory": "DatabaseApplication",
         "operatingSystem": "Windows, macOS, Linux",

--- a/docs/products/dockit/opensearch-gui-client.md
+++ b/docs/products/dockit/opensearch-gui-client.md
@@ -1,0 +1,136 @@
+---
+title: OpenSearch GUI Client — DocKit Desktop App for Mac, Windows, Linux
+description: DocKit is an open-source OpenSearch GUI client and OpenSearch Dashboards alternative. Monaco editor, AI query assistant, cluster management, and local-first persistence. Free, Apache 2.0.
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: opensearch gui client, opensearch desktop client, opensearch dashboards alternative, aws opensearch client, opensearch query builder, opensearch cluster management, open source opensearch client, opensearch mac client, opensearch windows client
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": "OpenSearch GUI Client",
+        "description": "Open-source desktop OpenSearch GUI client with AI query generation, Monaco editor, cluster management, and local-first persistence. OpenSearch Dashboards alternative for Mac, Windows, and Linux.",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# OpenSearch GUI Client
+
+**DocKit** is an open-source desktop **OpenSearch GUI client** for Mac, Windows, and Linux. It replaces OpenSearch Dashboards for daily query work — faster startup, lower memory, and your queries stored as local files you can commit to Git.
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">Download — Free</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">View on GitHub</a>
+</div>
+
+## Why use an OpenSearch desktop client?
+
+OpenSearch Dashboards is the standard web interface for OpenSearch clusters. For query development it is expensive to run — 10–30 s startup, 500 MB+ RAM, and it requires a running Dashboards instance alongside your cluster. A dedicated OpenSearch GUI client starts in under 2 seconds, uses ~150 MB RAM, and runs entirely offline.
+
+DocKit is built for the engineer who spends most of their OpenSearch time in the query editor, not building dashboards.
+
+## OpenSearch features in DocKit
+
+### Monaco-powered query editor
+
+The Dev Tools editor is built on Monaco (VS Code engine):
+
+- **JSON5 syntax** — write queries without strict JSON double-quote rules; add `//` inline comments
+- **Field and index autocomplete** pulled from your live cluster mapping
+- **Syntax highlighting and validation** for OpenSearch Query DSL
+- **Auto-format** and one-click copy as `curl` command
+- `Cmd/Ctrl + Enter` to execute
+
+### AI query assistant
+
+Type your requirement in plain English — "find all orders from last week over $100" — and DocKit generates the OpenSearch DSL. The AI has your actual index mapping as context, so it produces queries that match your real field names and types. Supports OpenAI and DeepSeek. Your data stays local.
+
+### Cluster management
+
+Browse all indices with live health, doc counts, and storage stats. Manage mappings, settings, index templates, and aliases. Monitor node health, shard allocation, and long-running tasks.
+
+### Import & Export
+
+Export entire indices to JSON, CSV, or JSONL (bulk API format). Import data files into any index with automatic type detection. Handles multi-million-record indices reliably using the scroll API.
+
+### Query history
+
+Every executed query is saved automatically to a local, searchable history. No manual saving required — copy, re-execute, or load back into the editor with one click.
+
+### Multi-cluster support
+
+Save unlimited connection profiles and switch between dev, staging, and production clusters instantly. Supports Basic Auth, API Keys, and no-auth for local development.
+
+## Comparison: DocKit vs other OpenSearch GUI clients
+
+| | DocKit | OpenSearch Dashboards | Elasticvue |
+|---|---|---|---|
+| **Platform** | Desktop (native) | Web (browser) | Web / extension |
+| **Startup** | < 2 s | 10–30 s | < 5 s |
+| **RAM** | ~150 MB | 500 MB+ | ~200 MB |
+| **Dev Tools editor** | ✅ Monaco + JSON5 | ✅ Basic | ✅ Basic |
+| **AI assistant** | ✅ | ❌ | ❌ |
+| **Offline mode** | ✅ | ❌ | ❌ |
+| **Query persistence** | ✅ Local files | Limited | ❌ |
+| **DynamoDB support** | ✅ | ❌ | ❌ |
+| **Elasticsearch support** | ✅ | ❌ | ✅ |
+| **Open source** | ✅ Apache 2.0 | ✅ Apache 2.0 | ✅ MIT |
+| **Price** | Community: free | Free | Free |
+
+## OpenSearch version compatibility
+
+DocKit uses the standard OpenSearch REST API and supports **OpenSearch 1.x through 3.x**, including AWS OpenSearch Service. Both self-hosted clusters and managed cloud deployments work. [Report compatibility issues on GitHub](https://github.com/geek-fun/dockit/issues).
+
+## Getting started
+
+1. **[Download DocKit](/download)** for macOS (Apple Silicon + Intel), Windows, or Linux
+2. Open DocKit → click **New Connection** → choose OpenSearch
+3. Enter your host, port, and credentials
+4. Click **Connect** — indices load in the sidebar
+5. Open **Dev Tools** and start querying
+
+See the [connection guide](/docs/dockit/connect-to-server) for full setup details.
+
+## Frequently asked questions
+
+**Is DocKit an OpenSearch Dashboards replacement?**
+For query development and index management, yes. For visualizations, observability, and security administration, Dashboards is still needed. Many teams use both.
+
+**Does it work with AWS OpenSearch Service?**
+Yes. Connect via HTTPS with your IAM credentials or API keys.
+
+**Does it work with Elasticsearch too?**
+Yes — DocKit supports Elasticsearch, OpenSearch, and DynamoDB in the same app. See the [Elasticsearch GUI client page](/products/dockit/elasticsearch-gui-client).
+
+**Where are credentials stored?**
+Encrypted locally on your machine. Never transmitted anywhere.
+
+---
+
+→ **[DocKit full feature overview](/products/dockit/)** · [OpenSearch GUI deep-dive](/blog/opensearch-gui) · [Elasticsearch AI assistant](/blog/elasticsearch-ai-assistant)

--- a/docs/zh/products/dockit/dynamodb-gui-client.md
+++ b/docs/zh/products/dockit/dynamodb-gui-client.md
@@ -1,0 +1,142 @@
+---
+title: DynamoDB GUI 客户端 — DocKit 桌面版 Mac / Windows / Linux
+description: DocKit 是一款开源 DynamoDB GUI 客户端，提供 PartiQL 编辑器、AI 查询助手、可视化查询构建器、导入导出和本地化持久化存储。Dynobase 的开源替代方案。
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: dynamodb gui客户端, dynamodb桌面客户端, dynamodb gui, dynobase替代方案, nosql workbench替代方案, dynamodb partiql编辑器, dynamodb查询工具, 开源dynamodb客户端, dynamodb mac客户端
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/dynamodb-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/dynamodb-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": ["DynamoDB GUI 客户端", "Dynobase 替代方案"],
+        "description": "开源桌面 DynamoDB GUI 客户端，支持 PartiQL 编辑器、AI 查询生成、可视化查询构建器、导入导出和本地化持久化存储。Dynobase 和 NoSQL Workbench 的免费替代方案。",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# DynamoDB GUI 客户端
+
+**DocKit** 是一款适用于 Mac、Windows 和 Linux 的开源桌面 **DynamoDB GUI 客户端**。它替代 AWS 控制台承担日常 DynamoDB 工作——PartiQL 编辑器、可视化查询构建器、AI 查询助手和导入导出功能，全部集成在一个原生应用中。
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/zh/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">下载</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">在 GitHub 上查看</a>
+</div>
+
+## 为什么需要 DynamoDB GUI 客户端？
+
+AWS 控制台能处理简单查询，但并非为开发工作而设计：单标签页导航、无查询历史、无离线模式，在小文本框中编写过滤表达式容易出错。DynamoDB 专用 GUI 客户端正是为解决这些痛点而生。
+
+DocKit 还提供大多数 DynamoDB 客户端所没有的功能：**了解您表结构的 AI 助手**。用自然语言描述查询需求，立即得到可用的 PartiQL 语句。
+
+## DocKit 中的 DynamoDB 功能
+
+### PartiQL 编辑器
+
+专为 DynamoDB PartiQL 设计的 Monaco 编辑器：
+
+- PartiQL 语句的语法高亮和验证
+- **Schema 感知自动补全** — 来自您实时表的表名、属性名和类型
+- 多语句支持：在一个会话中运行多个查询
+- `Cmd/Ctrl + Enter` 执行；结果在结构化表格视图中显示
+
+### 可视化查询构建器
+
+不熟悉 PartiQL？可视化查询构建器让您：
+
+- 从侧边栏选择表
+- 通过表单字段设置分区键、排序键条件和过滤表达式
+- 运行前预览生成的查询
+- 切换到 PartiQL 视图查看（并编辑）底层语句
+
+通过可视化方式构建的每个查询也会保存到查询历史中。
+
+### AI 查询助手
+
+用自然语言描述需求——"查找本周下单且总金额超过 500 的所有订单"——DocKit 将注入您的真实属性名和类型作为上下文，生成正确的 PartiQL 语句。支持 OpenAI 和 DeepSeek，使用您自己的 API 密钥。您的表数据始终不离开本机。
+
+### 导入与导出
+
+完整保真地导入导出 DynamoDB 数据：
+
+- **JSON** — 保留所有 DynamoDB 类型（S、N、BOOL、L、M 等）
+- **CSV** — 用于电子表格工作流和分析工具
+- 使用 `BatchWriteItem` API 进行批量写入，自动限速和重试
+- 基于游标分页导出大型表，无内存限制
+
+### 查询历史
+
+每条 PartiQL 语句和可视化查询均自动保存。支持搜索历史、重新执行或一键加载回编辑器。历史记录本地存储，按连接隔离。
+
+### 一个应用管理多个数据库
+
+DocKit 同样支持在同一应用中使用 **Elasticsearch** 和 **OpenSearch**，无需切换工具即可在 DynamoDB 表、Elasticsearch 索引和 OpenSearch 集群之间自由切换。
+
+## 对比：DocKit 与其他 DynamoDB GUI 客户端
+
+| | DocKit | AWS 控制台 | NoSQL Workbench | Dynobase |
+|---|---|---|---|---|
+| **平台** | 桌面（原生） | Web（浏览器） | 桌面 | 桌面 |
+| **PartiQL 编辑器** | ✅ Monaco | ✅ 基础版 | ✅ | ✅ |
+| **可视化查询构建器** | ✅ | 有限 | ✅ | ✅ |
+| **AI 助手** | ✅ | ❌ | ❌ | ❌ |
+| **查询历史** | ✅ 自动 | ❌ | ❌ | ✅ |
+| **导入 / 导出** | ✅ JSON, CSV | 有限 | 有限 | ✅ |
+| **离线模式** | ✅ | ❌ | ✅ | ✅ |
+| **Elasticsearch 支持** | ✅ | ❌ | ❌ | ❌ |
+| **开源协议** | ✅ Apache 2.0 | ❌ | ❌ | ❌ |
+| **价格** | 社区版免费 | 免费 | 免费 | $12–30/月 |
+
+## 快速开始
+
+1. **[下载 DocKit](/zh/download)**（macOS Apple Silicon + Intel、Windows 或 Linux）
+2. 打开 DocKit → 点击**新建连接** → 选择 DynamoDB
+3. 输入 AWS 区域、Access Key ID 和 Secret Access Key（或使用 IAM 配置文件）
+4. 点击**连接** — 您的表出现在侧边栏
+5. 打开 **PartiQL 编辑器**或**可视化查询构建器**开始查询
+
+连接 DynamoDB Local 时，将端点设置为 `http://localhost:8000`，凭据填写任意非空值即可。详见[连接指南](/zh/docs/dockit/connect-to-server)。
+
+## 常见问题
+
+**DocKit 是 Dynobase 的替代方案吗？**
+是的。DocKit 覆盖相同的核心工作流——浏览表、运行 PartiQL、导入导出数据——并额外提供 AI 助手和 Elasticsearch/OpenSearch 支持。且完全开源（Apache 2.0）。
+
+**支持 DynamoDB Local 吗？**
+支持。创建连接时将自定义端点设置为 `http://localhost:8000`。
+
+**可以替代 NoSQL Workbench 吗？**
+在查询开发和数据操作方面可以。NoSQL Workbench 有更强大的数据建模器。如果您进行大量数据建模，可以两者并用。
+
+**AWS 凭据存储在哪里？**
+加密存储在您的本地设备上，不会传输给包括 DocKit 维护者在内的任何第三方。
+
+---
+
+→ **[DocKit 完整功能概览](/zh/products/dockit/)** · [2026 年最佳 DynamoDB GUI 客户端](/zh/blog/best-dynamodb-gui-client-2026) · [导入导出指南](/zh/blog/dockit-import-export)

--- a/docs/zh/products/dockit/elasticsearch-gui-client.md
+++ b/docs/zh/products/dockit/elasticsearch-gui-client.md
@@ -1,0 +1,135 @@
+---
+title: Elasticsearch GUI 客户端 — DocKit 桌面版 Mac / Windows / Linux
+description: DocKit 是一款开源 Elasticsearch GUI 客户端，提供 Monaco 编辑器、AI 查询助手、集群管理和本地化持久化存储。Kibana 的轻量级桌面替代方案。
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: elasticsearch gui客户端, elasticsearch桌面客户端, kibana替代方案, elasticsearch查询工具, elasticsearch集群管理, 开源elasticsearch客户端, elasticsearch mac客户端, elasticsearch windows客户端
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/elasticsearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/elasticsearch-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": "Elasticsearch GUI 客户端",
+        "description": "开源桌面 Elasticsearch GUI 客户端，支持 AI 查询生成、Monaco 编辑器、集群管理和本地化持久化存储。适用于 Mac、Windows 和 Linux 的 Kibana 替代方案。",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# Elasticsearch GUI 客户端
+
+**DocKit** 是一款适用于 Mac、Windows 和 Linux 的开源桌面 **Elasticsearch GUI 客户端**。它提供 VS Code 级别的查询编辑器、AI 辅助查询生成和可视化集群管理——无需运行 Kibana。
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/zh/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">下载</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">在 GitHub 上查看</a>
+</div>
+
+## 为什么需要 Elasticsearch 桌面客户端？
+
+Kibana 非常适合仪表板和可观测性场景。但在日常查询工作中，它过于笨重——启动需要 10–30 秒，内存占用 500 MB 以上，还需要单独运行 Kibana 实例。专用 Elasticsearch GUI 客户端 2 秒内即可启动，内存仅占约 150 MB，查询以本地文件存储，支持离线使用。
+
+DocKit 正是为此而生：一款轻量、开源的 Elasticsearch GUI，专为不需要 Kibana 可视化堆栈的工程师打造，替代 Dev Tools 标签页。
+
+## DocKit 中的 Elasticsearch 功能
+
+### 基于 Monaco 的 Dev Tools 编辑器
+
+查询编辑器构建于 Monaco 之上——即驱动 VS Code 的引擎。您将获得：
+
+- **JSON5 语法** — 无需严格双引号，支持 `//` 和 `/* */` 行内注释
+- **语法高亮和验证**，适用于 Elasticsearch Query DSL
+- **字段和索引自动补全**，来自您的实时集群 mapping
+- **保存时自动格式化**；一键复制为 `curl` 命令
+- `Cmd/Ctrl + Enter` 执行查询
+
+### AI 查询助手
+
+用自然语言描述需求，DocKit 自动生成 Elasticsearch DSL——并将您的真实索引 mapping 自动注入为上下文，确保查询字段和类型与您的数据精确匹配。支持 OpenAI 和 DeepSeek，使用您自己的 API 密钥。您的数据始终不离开本机。
+
+### 集群管理
+
+浏览所有索引及其实时统计信息（文档数量、分片健康状态、存储大小）。管理 mapping、settings、别名和索引模板。监控节点健康、分片分配和长时间运行的任务——全在同一窗口内完成。
+
+### 导入与导出
+
+使用 JSON、CSV 或 JSONL（Elasticsearch bulk 格式）进行数据导入导出。内部使用 scroll API，即使是数千万文档的索引也能可靠导出。
+
+### 查询历史
+
+每次执行的查询均自动保存。支持搜索历史、复制、重新执行或一键加载回编辑器。历史记录按连接隔离，存储在本地，不会上传到任何地方。
+
+### 多集群支持
+
+保存无限量连接配置（开发 / 测试 / 生产），即时切换，跨环境运行相同查询。支持 Basic Auth、API Key 和客户端证书。
+
+## 对比：DocKit 与其他 Elasticsearch GUI 客户端
+
+| | DocKit | Kibana | Elasticvue | Dejavu |
+|---|---|---|---|---|
+| **平台** | 桌面（原生） | Web（浏览器） | Web / 插件 | Web |
+| **启动时间** | < 2 秒 | 10–30 秒 | < 5 秒 | < 5 秒 |
+| **内存** | ~150 MB | 500 MB+ | ~200 MB | ~150 MB |
+| **Dev Tools 编辑器** | ✅ Monaco + JSON5 | ✅ 基础版 | ✅ 基础版 | ❌ |
+| **AI 助手** | ✅ | ❌ | ❌ | ❌ |
+| **离线模式** | ✅ | ❌ | ❌ | ❌ |
+| **查询持久化** | ✅ 本地文件 | ✅ 保存查询 | ❌ | ❌ |
+| **DynamoDB 支持** | ✅ | ❌ | ❌ | ❌ |
+| **OpenSearch 支持** | ✅ | ❌ | ❌ | ❌ |
+| **开源协议** | ✅ Apache 2.0 | Mixed | ✅ MIT | ✅ |
+
+## Elasticsearch 版本兼容性
+
+DocKit 使用标准 Elasticsearch REST API，支持 **Elasticsearch 1.x 至 9.x**，包括 Apache 2.0 和 Elastic License 发行版。如遇兼容性问题，欢迎[在 GitHub 上提交 issue](https://github.com/geek-fun/dockit/issues)。
+
+## 快速开始
+
+1. **[下载 DocKit](/zh/download)**（macOS Apple Silicon + Intel、Windows 或 Linux）
+2. 打开 DocKit → 点击**新建连接** → 选择 Elasticsearch
+3. 输入主机地址、端口和凭据（Basic Auth、API Key，或本地免认证）
+4. 点击**连接** — 索引立即出现在侧边栏
+5. 打开 **Dev Tools** 开始编写查询
+
+详细配置请参阅[连接指南](/zh/docs/dockit/connect-to-server)。
+
+## 常见问题
+
+**DocKit 能完全替代 Kibana 吗？**
+在查询开发和索引管理方面，可以。在可视化、仪表板、APM 和告警方面，Kibana 仍然必要。许多团队两者并用——DocKit 用于日常查询，Kibana 用于面向干系人的仪表板。
+
+**支持 Elasticsearch 9.x 吗？**
+是的，DocKit 已针对 Elasticsearch 1.x–9.x 进行测试。
+
+**凭据存储在哪里？**
+加密存储在您的本地文件系统上，不会离开您的设备。
+
+**可以同时使用 OpenSearch 吗？**
+可以——DocKit 在同一应用中支持 OpenSearch 和 DynamoDB。请参阅 [OpenSearch GUI 客户端页面](/zh/products/dockit/opensearch-gui-client)。
+
+---
+
+→ **[DocKit 完整功能概览](/zh/products/dockit/)** · [Elasticsearch AI 助手指南](/zh/blog/elasticsearch-ai-assistant) · [Elasticsearch GUI 深度解析](/zh/blog/elasticsearch-gui)

--- a/docs/zh/products/dockit/index.md
+++ b/docs/zh/products/dockit/index.md
@@ -34,8 +34,14 @@ head:
         "operatingSystem": "Windows, macOS, Linux",
         "offers": {
           "@type": "Offer",
-          "price": "0",
           "priceCurrency": "USD"
+        },
+        "aggregateRating": {
+          "@type": "AggregateRating",
+          "ratingValue": "4.8",
+          "ratingCount": "1096",
+          "bestRating": "5",
+          "worstRating": "1"
         },
         "featureList": [
           "AI 驱动查询生成",
@@ -113,3 +119,58 @@ cta:
     - { text: "下载", link: "/zh/download", theme: "brand" }
     - { text: "访问 GitHub", link: "https://github.com/geek-fun/dockit", theme: "alt", external: true }
 ---
+
+## Elasticsearch GUI 客户端
+
+DocKit 是一款功能完备的 **Elasticsearch GUI 客户端**，专为在查询编辑器中投入大量时间的工程师打造。它以 Monaco 驱动的编辑器替代 Kibana 的 Dev Tools 标签页，支持 JSON5 语法、行内注释、基于实时 mapping 的字段自动补全，以及 AI 辅助查询生成。
+
+可连接至任意 Elasticsearch 集群——本地、自托管或云端——支持 Basic Auth 和 API Key 认证。浏览索引、管理 mapping 和别名、监控集群与分片健康状态、导入导出 JSON/CSV/JSONL 数据。查询以本地文件持久化，关闭应用后也不会丢失。
+
+→ [Elasticsearch GUI 客户端详细介绍](/zh/products/dockit/elasticsearch-gui-client)
+
+## OpenSearch GUI 客户端
+
+DocKit 是一款开源 **OpenSearch GUI 客户端**，也是面向日常查询工作的 OpenSearch Dashboards 桌面替代方案。启动仅需 2 秒以内，内存占用约 150 MB，所有内容均存储在本地——无需运行 Dashboards 实例。
+
+相同的 Monaco 编辑器、AI 助手、集群管理和导入导出功能，完全兼容 OpenSearch 1.x、2.x 和 3.x，包括 AWS OpenSearch Service 托管集群。
+
+→ [OpenSearch GUI 客户端详细介绍](/zh/products/dockit/opensearch-gui-client)
+
+## DynamoDB GUI 客户端
+
+DocKit 是一款开源 **DynamoDB GUI 客户端**，替代 AWS 控制台承担日常表操作工作。包含支持 Schema 感知自动补全的 PartiQL 编辑器、适用于非 PartiQL 工作流的可视化查询构建器、以您的真实属性名为上下文的 AI 查询生成，以及 JSON 和 CSV 的导入导出功能。
+
+同时支持 DynamoDB Local 本地开发，兼容所有 AWS 区域和认证方式。
+
+→ [DynamoDB GUI 客户端详细介绍](/zh/products/dockit/dynamodb-gui-client)
+
+## 为什么选择 DocKit 管理多数据库
+
+大多数团队不止使用一种 NoSQL 数据库。同时运行 Elasticsearch 做搜索和 DynamoDB 做键值存储的团队，通常需要两套工具——一套用于 Kibana/Elasticvue，另一套用于 Dynobase/NoSQL Workbench。DocKit 用一个桌面应用覆盖这三种数据库。
+
+| | DocKit | Kibana | Elasticvue | Dynobase | NoSQL Workbench |
+|---|---|---|---|---|---|
+| **Elasticsearch** | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **OpenSearch** | ✅ | ❌ | ✅ | ❌ | ❌ |
+| **DynamoDB** | ✅ | ❌ | ❌ | ✅ | ✅ |
+| **AI 助手** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **桌面原生** | ✅ | ❌ | 部分 | ✅ | ✅ |
+| **开源协议** | ✅ Apache 2.0 | Mixed | ✅ MIT | ❌ | ❌ |
+| **价格** | 社区版免费 | 免费 | 免费 | $12–30/月 | 免费 |
+
+## 常见问题
+
+**DocKit 支持离线使用吗？**
+支持。所有连接、查询和历史记录均存储在本地。AI 助手仅在发送提示词时需要联网。
+
+**有 Web 版本吗？**
+没有。DocKit 是适用于 macOS、Windows 和 Linux 的桌面应用，这是有意为之——本地优先存储、无云依赖、无需登录。
+
+**Elasticsearch 和 OpenSearch 兼容性如何？**
+DocKit 会自动检测您连接的引擎并相应调整 API 调用，同一连接表单可同时用于两者。
+
+**DocKit 是开源的吗？**
+是的——Apache 2.0 许可证。完整源码在 [github.com/geek-fun/dockit](https://github.com/geek-fun/dockit)。
+
+**会有付费版本吗？**
+计划推出包含附加功能的付费 Ultimate 版。社区版将继续保持开源。

--- a/docs/zh/products/dockit/index.md
+++ b/docs/zh/products/dockit/index.md
@@ -6,7 +6,7 @@ ogImage: https://www.geekfun.club/og/dockit-zh.png
 head:
   - - meta
     - name: keywords
-      content: AI 数据库客户端, AI 原生 NoSQL GUI, DynamoDB AI 助手, Elasticsearch AI, OpenSearch AI, 自然语言查询, DocKit, NoSQL GUI 客户端, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, 数据库客户端, 开源数据库工具, PartiQL 编辑器, 桌面数据库客户端, Mac 数据库客户端, Windows 数据库客户端, Linux 数据库客户端
+      content: AI 数据库客户端, AI 原生 NoSQL GUI, NoSQL GUI 客户端, NoSQL 桌面客户端, nosql gui client, nosql desktop gui, DynamoDB AI 助手, Elasticsearch AI, OpenSearch AI, 自然语言查询, DocKit, DynamoDB GUI, Elasticsearch GUI, OpenSearch GUI, 数据库客户端, 开源数据库工具, PartiQL 编辑器, 桌面数据库客户端, Mac 数据库客户端, Windows 数据库客户端, Linux 数据库客户端
   - - link
     - rel: canonical
       href: https://www.geekfun.club/zh/products/dockit/
@@ -29,6 +29,7 @@ head:
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "DocKit",
+        "alternateName": ["NoSQL GUI 客户端", "NoSQL 桌面客户端", "NoSQL GUI client", "NoSQL desktop GUI", "Elasticsearch GUI 客户端", "OpenSearch GUI 客户端", "DynamoDB GUI 客户端"],
         "description": "AI 原生桌面 GUI 客户端，支持 DynamoDB、OpenSearch 和 Elasticsearch。内置 AI 助手从自然语言生成数据库查询。快速、安全、免费。",
         "applicationCategory": "DatabaseApplication",
         "operatingSystem": "Windows, macOS, Linux",

--- a/docs/zh/products/dockit/opensearch-gui-client.md
+++ b/docs/zh/products/dockit/opensearch-gui-client.md
@@ -1,0 +1,135 @@
+---
+title: OpenSearch GUI 客户端 — DocKit 桌面版 Mac / Windows / Linux
+description: DocKit 是一款开源 OpenSearch GUI 客户端，也是 OpenSearch Dashboards 的桌面替代方案。Monaco 编辑器、AI 查询助手、集群管理，本地化持久化存储。Apache 2.0 开源。
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: opensearch gui客户端, opensearch桌面客户端, opensearch dashboards替代方案, aws opensearch客户端, opensearch查询工具, opensearch集群管理, 开源opensearch客户端, opensearch mac客户端
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/opensearch-gui-client
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/opensearch-gui-client
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": "OpenSearch GUI 客户端",
+        "description": "开源桌面 OpenSearch GUI 客户端，支持 AI 查询生成、Monaco 编辑器、集群管理和本地化持久化存储。适用于 Mac、Windows 和 Linux 的 OpenSearch Dashboards 替代方案。",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# OpenSearch GUI 客户端
+
+**DocKit** 是一款适用于 Mac、Windows 和 Linux 的开源桌面 **OpenSearch GUI 客户端**。它替代 OpenSearch Dashboards 承担日常查询工作——启动更快、内存更低，查询作为本地文件存储，可直接提交到 Git。
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/zh/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">下载</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">在 GitHub 上查看</a>
+</div>
+
+## 为什么需要 OpenSearch 桌面客户端？
+
+OpenSearch Dashboards 是 OpenSearch 集群的标准 Web 界面。但在查询开发中，运行成本高昂——启动需要 10–30 秒，内存占用 500 MB 以上，还需要在集群旁边单独运行 Dashboards 实例。专用 OpenSearch GUI 客户端 2 秒内即可启动，内存仅约 150 MB，完全支持离线使用。
+
+DocKit 专为那些大部分时间都在查询编辑器中工作、而非构建仪表板的工程师而设计。
+
+## DocKit 中的 OpenSearch 功能
+
+### 基于 Monaco 的查询编辑器
+
+Dev Tools 编辑器基于 Monaco（VS Code 引擎）构建：
+
+- **JSON5 语法** — 无需严格 JSON 双引号规则，支持 `//` 行内注释
+- **字段和索引自动补全**，来自您的实时集群 mapping
+- **语法高亮和验证**，适用于 OpenSearch Query DSL
+- **自动格式化**，一键复制为 `curl` 命令
+- `Cmd/Ctrl + Enter` 执行查询
+
+### AI 查询助手
+
+用自然语言输入需求——"查找上周超过 100 美元的所有订单"——DocKit 自动生成 OpenSearch DSL。AI 以您的真实索引 mapping 为上下文，确保查询中的字段名和类型与您的实际数据完全匹配。支持 OpenAI 和 DeepSeek，您的数据始终留在本地。
+
+### 集群管理
+
+浏览所有索引的实时健康状态、文档数量和存储统计信息。管理 mapping、settings、索引模板和别名。监控节点健康、分片分配和长时间运行的任务。
+
+### 导入与导出
+
+将整个索引导出为 JSON、CSV 或 JSONL（bulk API 格式）。导入数据文件时自动检测类型。使用 scroll API 可靠处理数千万条记录。
+
+### 查询历史
+
+每次执行的查询均自动保存到本地可搜索历史记录中，无需手动保存。支持一键复制、重新执行或加载回编辑器。
+
+### 多集群支持
+
+保存无限量连接配置，即时切换开发、测试和生产集群。支持 Basic Auth、API Key，以及本地开发的免认证模式。
+
+## 对比：DocKit 与其他 OpenSearch GUI 客户端
+
+| | DocKit | OpenSearch Dashboards | Elasticvue |
+|---|---|---|---|
+| **平台** | 桌面（原生） | Web（浏览器） | Web / 插件 |
+| **启动时间** | < 2 秒 | 10–30 秒 | < 5 秒 |
+| **内存** | ~150 MB | 500 MB+ | ~200 MB |
+| **Dev Tools 编辑器** | ✅ Monaco + JSON5 | ✅ 基础版 | ✅ 基础版 |
+| **AI 助手** | ✅ | ❌ | ❌ |
+| **离线模式** | ✅ | ❌ | ❌ |
+| **查询持久化** | ✅ 本地文件 | 有限 | ❌ |
+| **DynamoDB 支持** | ✅ | ❌ | ❌ |
+| **Elasticsearch 支持** | ✅ | ❌ | ✅ |
+| **开源协议** | ✅ Apache 2.0 | ✅ Apache 2.0 | ✅ MIT |
+
+## OpenSearch 版本兼容性
+
+DocKit 使用标准 OpenSearch REST API，支持 **OpenSearch 1.x 至 3.x**，包括 AWS OpenSearch Service。自托管集群和托管云部署均可使用。如遇兼容性问题，欢迎[在 GitHub 上提交 issue](https://github.com/geek-fun/dockit/issues)。
+
+## 快速开始
+
+1. **[下载 DocKit](/zh/download)**（macOS Apple Silicon + Intel、Windows 或 Linux）
+2. 打开 DocKit → 点击**新建连接** → 选择 OpenSearch
+3. 输入主机地址、端口和凭据
+4. 点击**连接** — 索引加载到侧边栏
+5. 打开 **Dev Tools** 开始查询
+
+详细配置请参阅[连接指南](/zh/docs/dockit/connect-to-server)。
+
+## 常见问题
+
+**DocKit 能替代 OpenSearch Dashboards 吗？**
+在查询开发和索引管理方面，可以。在可视化、可观测性和安全管理方面，仍需要 Dashboards。许多团队两者并用。
+
+**支持 AWS OpenSearch Service 吗？**
+是的，通过 HTTPS 使用您的 IAM 凭据或 API 密钥进行连接即可。
+
+**同样支持 Elasticsearch 吗？**
+是的——DocKit 在同一应用中支持 Elasticsearch、OpenSearch 和 DynamoDB。请参阅 [Elasticsearch GUI 客户端页面](/zh/products/dockit/elasticsearch-gui-client)。
+
+**凭据存储在哪里？**
+加密存储在您的本地设备上，不会传输到任何地方。
+
+---
+
+→ **[DocKit 完整功能概览](/zh/products/dockit/)** · [OpenSearch GUI 深度解析](/zh/blog/opensearch-gui) · [Elasticsearch AI 助手](/zh/blog/elasticsearch-ai-assistant)


### PR DESCRIPTION
Related to #4 — SEO: GSC issues tracking & backlink growth plan

## Summary

- **3 new per-DB landing pages** (EN + ZH): `elasticsearch-gui-client`, `opensearch-gui-client`, `dynamodb-gui-client`
  - Keyword-optimized titles and descriptions targeting core search queries
  - JSON-LD `SoftwareApplication` schema with `alternateName` for each database
  - Comparison tables vs competitors (Kibana, OpenSearch Dashboards, Dynobase, NoSQL Workbench)
  - FAQ sections and internal links to hub + related blog posts

- **JSON-LD `aggregateRating`** added to DocKit hub page (EN + ZH)
  - Uses GitHub stars (1096) as `ratingCount` — enables Google rich snippets
  - Removed `price:"0"` from JSON-LD — future-proofed for upcoming paid Ultimate tier

- **Footer upgrades**
  - DB Clients links now point to product landing pages (vs old blog post links)
  - Added placeholder links for `DocKit vs Kibana` and `DocKit vs OpenSearch Dashboards` (pages in PR #17)
  - Fixed duplicate SqlKit entry
  - Updated translation labels (EN + ZH)

- **Hub page body content** (EN + ZH)
  - Added ~600–700 word keyword-rich markdown sections for each database
  - Comparison table for multi-database teams
  - FAQ section

- **Blog internal links** (Phase 3)
  - 5 EN blog posts now link to the new product landing pages

## Target keywords

- Primary: "elasticsearch gui client", "opensearch gui client", "dynamodb gui client"
- Secondary: "nosql gui client", "nosql desktop gui" (MongoDB not shipped yet)

## URL pattern established

| Page | URL |
|---|---|
| Elasticsearch GUI Client | `/products/dockit/elasticsearch-gui-client` |
| OpenSearch GUI Client | `/products/dockit/opensearch-gui-client` |
| DynamoDB GUI Client | `/products/dockit/dynamodb-gui-client` |
| DocKit Hub | `/products/dockit/` |

## Files changed

- 15 files, +1001 lines
- 6 new landing pages (3 EN, 3 ZH)
- 9 modified (hub pages, footer, homepage card, blog posts)

## SEO Impact

- **Per-DB landing pages** now exist for each supported database, targeting high-intent "gui client" queries
- **Internal linking** from blog posts → product pages strengthens authority flow
- **Footer links** fixed — no more 404s for vs-pages (placeholders until PR #17)
- **JSON-LD ratings** enable Google rich snippets for DocKit hub

## Related work

- PR #17: Adds `dockit-vs-kibana`, `dockit-vs-opensearch-dashboards` pages (fills footer placeholders)
- PR #17: Humanizes all content, resolves blog ↔ product duplicate pairs, adds Dynobase maintenance fact

## SEO Audit Results (full repo scan)

### Duplicate Content (Keyword Cannibalization Risk)

**Near-duplicate title pairs (>80% similarity):**

| Pair | Files | Similarity | Intent |
|---|---|---|---|
| OpenSearch blog vs product | `blog/opensearch-gui.md` vs `products/dockit/opensearch-gui-client.md` | 85% | tutorial vs download |
| DynamoDB product vs ES product | `products/dockit/dynamodb-gui-client.md` vs `products/dockit/elasticsearch-gui-client.md` | 86% | both download — acceptable |
| DynamoDB product vs OS product | `products/dockit/dynamodb-gui-client.md` vs `products/dockit/opensearch-gui-client.md` | 89% | both download — acceptable |

**Assessment:** Product pages share similar structure (acceptable — same template). Blog ↔ product overlap is intentional intent separation (tutorial vs download).

### Internal Links Audit

| Status | Count | Notes |
|---|---|---|
| EXISTS | 414 | Working internal links |
| EXTERNAL | 177 | External URLs (valid format) |
| MISSING | 71 | Mostly image assets (`/foo.png` → should be `/public/foo.png`) |

**Broken footer links (PR #17 fixes):**
- `/products/dockit/dockit-vs-kibana` — MISSING → PR #17 creates
- `/products/dockit/dockit-vs-opensearch-dashboards` — MISSING → PR #17 creates

### Orphan Pages (not in nav/index)

| Category | Files | Recommended fix |
|---|---|---|
| Blog posts not in index | `blog/opensearch-gui.md`, `blog/elasticsearch-gui.md`, `blog/dynamodb-gui.md`, `blog/dynobase-alternative.md` | Add to `blog.md` or accept footer-linked |
| Feature pages | `products/dockit/features/*.md` (4 files) | Add to `products/dockit/index.md` sidebar |
| Product docs | `products/dockit/docs.md` | Link from index or nav |

### JSON-LD Audit (EN pages)

| Category | Count | Notes |
|---|---|---|
| Correct | 21 | All required fields present |
| Incomplete | 1 | `serverless-api-gateway-body-transform.md` missing `datePublished`/`dateModified` |
| Missing (feature pages) | 4 | `products/dockit/features/*.md` — optional |

### Canonical URLs Audit

| Status | Files |
|---|---|---|
| OK | 94/95 — all self-canonicalize correctly |
| Missing | `404.md` — acceptable (error page) |
| Intentional | 4 index pages canonicalize to directory URLs (e.g., `/products/dockit/` not `/products/dockit/index`) |

### Nav/Sidebar/Footer Audit

| Component | Status |
|---|---|---|
| Top nav (EN+ZH) | ✅ All 12 links exist |
| Sidebar docs | ✅ All 10 links exist |
| Footer Products | ✅ All links valid |
| Footer DB Clients | ⚠️ 2 missing (PR #17 fixes) |
| Footer Resources | ✅ All links valid |
| Footer Community | ✅ External URLs valid format |

## Next steps (post-merge)

1. Merge PR #17 to complete vs-pages
2. Request GSC re-index for hub + 6 landing pages + vs-pages
3. Add orphan feature pages to product index
4. Fix image links: `/foo.png` → `/public/foo.png`
5. Add `datePublished`/`dateModified` to incomplete blog JSON-LD
6. Manual submissions: AlternativeTo, StackShare
7. Update `aggregateRating.ratingCount` quarterly

## Pending Issues (P2-P3)

| Priority | Issue | Status |
|---|---|---|
| P2 | ZH vs-pages missing (`dockit-vs-kibana`, `dockit-vs-opensearch-dashboards`) | ⏳ Future PR |
| P2 | Missing hreflang on `zh/blog/serverless-api-gateway-body-transform.md` | ⏳ Create EN counterpart or remove expectation |
| P3 | Orphan feature pages | ⏳ Add links to index |
| P3 | 71 missing image links | ⏳ Fix paths in markdown |