### PR TITLE
seo: P2 — ZH vs-pages, orphan feature links, hreflang + JSON-LD fixes

### DIFF
--- a/docs/blog/serverless-api-gateway-body-transform.md
+++ b/docs/blog/serverless-api-gateway-body-transform.md
@@ -40,6 +40,8 @@ head:
             "url": "https://www.geekfun.club/geekfun.png"
           }
         },
+        "datePublished": "2026-04-15",
+        "dateModified": "2026-04-15",
         "mainEntityOfPage": {
           "@type": "WebPage",
           "@id": "https://www.geekfun.club/blog/serverless-api-gateway-body-transform"

--- a/docs/products/dockit/index.md
+++ b/docs/products/dockit/index.md
@@ -179,3 +179,10 @@ Yes — Apache 2.0 license. The full source is at [github.com/geek-fun/dockit](h
 
 **Will there be a paid tier?**
 A paid Ultimate tier with additional features is planned. The Community edition will remain open-source.
+
+## More on DocKit
+
+- [Desktop-native app architecture](/products/dockit/features/desktop-client) — why a native Tauri/Rust app beats Electron for database tooling
+- [DynamoDB PartiQL editor](/products/dockit/features/dynamodb-partiql) — SQL-like queries against DynamoDB with syntax highlighting and autocomplete
+- [Local-first design](/products/dockit/features/local-first) — how DocKit keeps your queries, credentials, and history on your machine
+- [Open-source Apache 2.0](/products/dockit/features/open-source) — full source access, no vendor lock-in

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -4,7 +4,7 @@
 # Old .html extension URLs - 301 permanent redirect
 /download.html  /download  301
 /about.html     /about     301
-/products.html  /products  301
+/products.html  /products/  301
 /blog.html      /blog      301
 /news.html      /news      301
 /docs.html      /docs      301
@@ -12,7 +12,7 @@
 # Chinese pages with .html
 /zh/download.html  /zh/download  301
 /zh/about.html     /zh/about     301
-/zh/products.html  /zh/products  301
+/zh/products.html  /zh/products/  301
 /zh/blog.html      /zh/blog      301
 /zh/news.html      /zh/news      301
 

--- a/docs/zh/blog/serverless-api-gateway-body-transform.md
+++ b/docs/zh/blog/serverless-api-gateway-body-transform.md
@@ -8,6 +8,18 @@ head:
   - - link
     - rel: canonical
       href: https://www.geekfun.club/zh/blog/serverless-api-gateway-body-transform
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/serverless-api-gateway-body-transform
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/serverless-api-gateway-body-transform
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/serverless-api-gateway-body-transform
   - - script
     - type: application/ld+json
     - |
@@ -28,6 +40,8 @@ head:
             "url": "https://www.geekfun.club/geekfun.png"
           }
         },
+        "datePublished": "2026-04-15",
+        "dateModified": "2026-04-15",
         "mainEntityOfPage": {
           "@type": "WebPage",
           "@id": "https://www.geekfun.club/zh/blog/serverless-api-gateway-body-transform"

--- a/docs/zh/products/dockit/dockit-vs-kibana.md
+++ b/docs/zh/products/dockit/dockit-vs-kibana.md
@@ -95,13 +95,7 @@ DocKit 在同一个应用里支持 Elasticsearch、OpenSearch 和 DynamoDB。如
 
 ## 什么时候 Kibana 更合适
 
-如果你需要以下功能，保留 Kibana：
-
-- **大盘和可视化**：Kibana Lens 和 Canvas 是给干系人做图表的黄金标准。
-- **APM 和链路追踪**：Elastic APM、分布式追踪和 Service Maps 都是 Kibana 原生的。
-- **告警**：内置基于规则的告警，支持 PagerDuty 或 Slack 连接器。
-- **机器学习**：Elastic ML 异常检测就在 Kibana 里。
-- **共享浏览器访问**：如果非技术人员也需要看数据，Web 界面是唯一选择。
+查询开发以外的场景，Kibana 没有替代品。Kibana Lens 和 Canvas 是给干系人做图表的事实标准；Elastic APM、分布式追踪和 Service Maps 全是 Kibana 原生的；基于规则的告警支持 PagerDuty 和 Slack 连接器；Elastic ML 异常检测也在里面。如果非技术人员需要访问数据，Web 界面是唯一合理的选择。
 
 大多数工程师两个都在用。DocKit 负责查询开发和索引管理，Kibana 负责大盘和可观测。
 

--- a/docs/zh/products/dockit/dockit-vs-kibana.md
+++ b/docs/zh/products/dockit/dockit-vs-kibana.md
@@ -1,0 +1,144 @@
+---
+title: DocKit vs Kibana — Elasticsearch 桌面客户端 vs Kibana Dev Tools
+description: DocKit 与 Kibana 的查询开发对比。DocKit 是 Kibana Dev Tools 的轻量开源桌面替代方案——启动更快、内存占用更低、支持离线模式和 AI 查询助手。
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: dockit vs kibana, kibana 替代方案, kibana dev tools 替代方案, elasticsearch 桌面客户端, elasticsearch gui, 开源 kibana 替代方案, kibana replacement, elasticsearch 客户端 mac, elasticsearch 客户端 windows
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/products/dockit/dockit-vs-kibana
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/dockit-vs-kibana
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/dockit-vs-kibana
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/dockit-vs-kibana
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": ["Kibana 替代方案", "Kibana Dev Tools 替代方案", "Elasticsearch 桌面客户端"],
+        "description": "开源桌面 Elasticsearch GUI 客户端，支持 AI 查询生成、Monaco 编辑器和本地优先持久化。适用于 Mac、Windows 和 Linux 的轻量 Kibana Dev Tools 替代方案。",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# DocKit vs Kibana
+
+Kibana 是做大盘和可观测的标准 UI，但用来写日常查询就太重了。你得额外跑一个服务，等它启动个 30 秒，还要让它吃掉 500MB 内存，就为了打开 Dev Tools 那个标签页。
+
+DocKit 是为 Elasticsearch 查询专门打造的原生桌面应用。两秒内启动，离线可用，查询保存成本地文件，可以直接纳入版本控制。
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/zh/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">下载 DocKit</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">GitHub 仓库</a>
+</div>
+
+## 功能对比
+
+| | DocKit | Kibana |
+|---|---|---|
+| **类型** | 原生桌面应用 | Web 应用（需要服务器） |
+| **启动时间** | < 2 秒 | 10–30 秒 |
+| **内存占用** | ~150 MB | 500 MB+ |
+| **需要 Kibana 服务器** | ❌ | ✅ |
+| **离线模式** | ✅ | ❌ |
+| **查询编辑器** | Monaco + JSON5 + 自动补全 | 基础 Dev Tools 控制台 |
+| **AI 查询助手** | ✅（OpenAI、DeepSeek） | ❌ |
+| **查询持久化** | ✅ 本地文件（Git 友好） | ✅ 服务端保存 |
+| **索引与集群管理** | ✅ | ✅ |
+| **可视化 / 大盘** | ❌ | ✅ |
+| **APM / 可观测** | ❌ | ✅ |
+| **告警** | ❌ | ✅ |
+| **DynamoDB / OpenSearch** | ✅ | ❌ |
+| **开源** | ✅ Apache 2.0 | 混合（基础免费，高级付费） |
+| **ES 版本支持** | 1.x – 9.x | 与 Stack 版本强绑定 |
+
+## 什么时候 DocKit 更合适
+
+### 你只需要一个查询编辑器
+
+Kibana Dev Tools 能用，但你不需要跑一整个服务器集群只是为了写一条 `GET /my-index/_search`。DocKit 提供更好的编辑器：Monaco 引擎（VS Code 同款）、JSON5 支持、基于实时 Mapping 的字段自动补全，还有自动格式化和 curl 导出，没有任何服务器开销。
+
+### 你经常在多个集群之间切换
+
+DocKit 保存连接配置，在 dev、staging 和 prod 之间一键切换。Kibana 通常只绑在它部署的那个集群上。DocKit 里换环境就是侧边栏点一下的事。
+
+### 你想用 AI 辅助写查询
+
+用自然语言描述需求，DocKit 把你的索引 Mapping 作为上下文喂给 AI，直接生成 DSL。Kibana 没有对应的功能。支持 OpenAI 和 DeepSeek，用你自己的 API Key，数据留在本地。
+
+### 你需要离线使用
+
+DocKit 安装后不依赖网络。查询、历史记录和凭证全在本地。Kibana 要求同时能访问它自己的服务器和 ES 集群，在 VPN 或本地开发环境下很麻烦。
+
+### 你的团队还用 DynamoDB 或 OpenSearch
+
+DocKit 在同一个应用里支持 Elasticsearch、OpenSearch 和 DynamoDB。如果你同时接触多种数据库，DocKit 能替代两三个工具。
+
+## 什么时候 Kibana 更合适
+
+如果你需要以下功能，保留 Kibana：
+
+- **大盘和可视化**：Kibana Lens 和 Canvas 是给干系人做图表的黄金标准。
+- **APM 和链路追踪**：Elastic APM、分布式追踪和 Service Maps 都是 Kibana 原生的。
+- **告警**：内置基于规则的告警，支持 PagerDuty 或 Slack 连接器。
+- **机器学习**：Elastic ML 异常检测就在 Kibana 里。
+- **共享浏览器访问**：如果非技术人员也需要看数据，Web 界面是唯一选择。
+
+大多数工程师两个都在用。DocKit 负责查询开发和索引管理，Kibana 负责大盘和可观测。
+
+## 编辑器的区别
+
+Kibana Dev Tools 用的是 CodeMirror 控制台，能用，但有一些烦人的限制：不支持 JSON5，所以必须严格用双引号，不能加内联注释；字段自动补全经常慢或者不全；没有 AI；保存的查询锁在服务器上。
+
+DocKit 的编辑器基于 Monaco。支持 JSON5，可以加注释和尾随逗号。自动补全在连接时直接从集群 Mapping 里取。还有 DSL 语法校验、自动格式化、一键复制成 `curl`。支持多标签，可以同时跑多条独立查询。完整的历史记录保存在本地，随时搜索和重放。
+
+## 连接 DocKit 到你的 Elasticsearch 集群
+
+1. **[下载 DocKit](/zh/download)**（macOS、Windows 或 Linux）。
+2. 打开 DocKit，点 **新建连接**，选 **Elasticsearch**。
+3. 填入地址、端口和认证信息。
+4. 点 **连接**，索引就会出现在侧边栏里。
+5. 打开 **Dev Tools** 开始查询。
+
+如果你的集群用了 TLS 或客户端证书，参考[连接指南](/docs/dockit/connect-to-server)。
+
+## Elasticsearch 版本支持
+
+DocKit 使用标准 REST API，支持 **Elasticsearch 1.x 到 9.x**，Apache 2.0 和 Elastic License 发行版都可以。Kibana 则与特定的 Stack 版本强绑定。
+
+## 常见问题
+
+**DocKit 是完整的 Kibana 替代方案吗？**
+不是，也不打算做成那样。在查询开发和索引管理上，DocKit 覆盖了相同的场景（还加了 AI 和离线）。在大盘、APM 和告警方面，Kibana 没有对应的替代。大多数团队两个都用。
+
+**DocKit 支持 Kibana 的保存查询格式吗？**
+不支持。DocKit 把查询存成本地文件（JSON）。可以从 Kibana Dev Tools 复制 DSL 到 DocKit，反过来也行——查询语言是一样的。
+
+**可以在 Elastic Cloud 上用 DocKit 吗？**
+可以。在连接对话框里填入 Elastic Cloud 的 endpoint 和 API Key 就行，所有 Elastic Cloud 套餐都支持。
+
+**DocKit 支持在 VPN 或跳板机后面的自建 Elasticsearch 吗？**
+支持，只要 DocKit 能访问 ES 的 REST 端口（默认 9200）就行。SSH 隧道在外部建好后，把 DocKit 指向 `localhost` 即可。
+
+---
+
+→ **[DocKit 完整功能概览](/products/dockit/)** · [Elasticsearch GUI 客户端页面](/products/dockit/elasticsearch-gui-client) · [Elasticsearch GUI 深度解析](/zh/blog/elasticsearch-gui)

--- a/docs/zh/products/dockit/dockit-vs-opensearch-dashboards.md
+++ b/docs/zh/products/dockit/dockit-vs-opensearch-dashboards.md
@@ -1,0 +1,166 @@
+---
+title: DocKit vs OpenSearch Dashboards — 桌面客户端 vs Dashboards Dev Tools
+description: DocKit 与 OpenSearch Dashboards 的查询开发对比。DocKit 是轻量的开源桌面替代方案——启动更快、支持离线模式、AI 助手加持，无需服务器。
+sidebar: false
+head:
+  - - meta
+    - name: keywords
+      content: dockit vs opensearch dashboards, opensearch dashboards 替代方案, opensearch 桌面客户端, opensearch gui 客户端, opensearch dev tools 替代方案, 开源 opensearch 客户端, opensearch 客户端 mac, opensearch 客户端 windows, aws opensearch gui
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/products/dockit/dockit-vs-opensearch-dashboards
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/products/dockit/dockit-vs-opensearch-dashboards
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/products/dockit/dockit-vs-opensearch-dashboards
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/products/dockit/dockit-vs-opensearch-dashboards
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "DocKit",
+        "alternateName": ["OpenSearch Dashboards 替代方案", "OpenSearch 桌面客户端", "OpenSearch GUI 客户端"],
+        "description": "开源桌面 OpenSearch GUI 客户端，支持 AI 查询生成、Monaco 编辑器和本地优先持久化。适用于 Mac、Windows 和 Linux 的轻量 OpenSearch Dashboards 替代方案。",
+        "applicationCategory": "DatabaseApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "offers": { "@type": "Offer", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.geekfun.club/download",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "license": "https://github.com/geek-fun/dockit/blob/main/LICENSE",
+        "sameAs": ["https://github.com/geek-fun/dockit"]
+      }
+---
+
+# DocKit vs OpenSearch Dashboards
+
+OpenSearch Dashboards 是 OpenSearch 的标准 Web 界面，主要用于可视化和监控，但日常查询开发用它太重了。它需要单独跑一个服务，10–30 秒的启动时间和 500MB+ 的内存开销，只是想快速跑个查询就显得很浪费。
+
+DocKit 是专为 OpenSearch 查询设计的原生桌面应用。两秒内启动，直接连到你的集群，查询本地存储，没有任何服务端依赖。
+
+<div style="display:flex;gap:12px;margin:1.5rem 0">
+  <a href="/zh/download" style="padding:10px 20px;background:var(--vp-c-brand-1);color:#fff;border-radius:6px;font-weight:600;text-decoration:none">下载 DocKit</a>
+  <a href="https://github.com/geek-fun/dockit" style="padding:10px 20px;border:1px solid var(--vp-c-border);border-radius:6px;font-weight:600;text-decoration:none" target="_blank" rel="noopener">GitHub 仓库</a>
+</div>
+
+## 功能对比
+
+| | DocKit | OpenSearch Dashboards |
+|---|---|---|
+| **类型** | 原生桌面应用 | Web 应用（需要服务器） |
+| **启动时间** | < 2 秒 | 10–30 秒 |
+| **内存占用** | ~150 MB | 500 MB+ |
+| **需要 Dashboards 服务器** | ❌ | ✅ |
+| **离线模式** | ✅ | ❌ |
+| **查询编辑器** | Monaco + JSON5 + 自动补全 | 基础 Dev Tools 控制台 |
+| **AI 查询助手** | ✅（OpenAI、DeepSeek） | ❌ |
+| **查询持久化** | ✅ 本地文件（Git 友好） | ✅ 服务端保存 |
+| **索引与集群管理** | ✅ | ✅ |
+| **可视化 / 大盘** | ❌ | ✅ |
+| **可观测 / 链路追踪** | ❌ | ✅ |
+| **告警** | ❌ | ✅ |
+| **DynamoDB / Elasticsearch** | ✅ | ❌ |
+| **AWS OpenSearch Service** | ✅ | ✅（托管版） |
+| **开源** | ✅ Apache 2.0 | ✅ Apache 2.0 |
+| **OS 版本支持** | 1.x – 3.x+ | 与集群版本强绑定 |
+
+## 什么时候 DocKit 更合适
+
+### 用 AWS OpenSearch Service
+
+AWS OpenSearch Service 提供了一个托管的 Dashboards 入口，但配置起来经常很麻烦，而且版本永远跟着集群走。DocKit 绕过 Dashboards，直接用你的 AWS 凭证（Access Key、IAM Role 或 Profile）连 OpenSearch REST API。
+
+### 更快的查询节奏
+
+浏览器工具有固有的摩擦感。Dashboards Dev Tools 标签页要等 Dashboards 实例在浏览器里加载完。DocKit 是原生应用，两秒就能用。如果你每天要跑几十条查询，省下来的时间很可观。
+
+### AI 辅助写查询
+
+用自然语言描述查询需求，DocKit 把你的索引 Mapping 作为上下文，生成对应的 OpenSearch DSL。支持 OpenAI 和 DeepSeek，用你自己的 API Key。OpenSearch Dashboards 没有对等的功能。
+
+### 查询纳入版本控制
+
+DocKit 把历史和保存的查询存成本地文件，可以直接提交到 Git 或作为代码分享给队友。查询记录跟着你走，不依赖当前在用的哪个 Dashboards 实例。
+
+### 同时用 Elasticsearch 或 DynamoDB
+
+在同一个应用里管理 OpenSearch、Elasticsearch 和 DynamoDB，不用在不同的工具之间来回切换。
+
+## 什么时候 OpenSearch Dashboards 更合适
+
+以下场景留着 Dashboards：
+
+- **大盘和可视化**：内置的引擎（Lens、TSVB）更适合给干系人做图表。
+- **告警和监控**：直接集成在集群里的基于规则告警。
+- **可观测管道**：Trace Analytics、Jaeger/Zipkin 集成和特定的日志分析视图。
+- **Security 插件 UI**：通过 Security 插件管理细粒度访问控制、角色和审计日志。
+- **共享访问**：需要一个团队所有人不装软件就能访问的浏览器 URL。
+
+大多数团队会两个都用：DocKit 给写查询的工程师，Dashboards 给共享监控和干系人报告。
+
+## 编辑器的区别
+
+OpenSearch Dashboards 里的 Dev Tools 控制台功能够用，但有局限——其实跟从 Kibana 继承来的那套差不多：
+
+- 必须用严格 JSON，不支持内联注释和尾随逗号。
+- Mapping 变更后字段自动补全更新慢。
+- 没有 AI 支持。
+- 保存的查询存在服务器上，绑定特定实例。
+- 不能方便地导出成 curl 命令。
+
+DocKit 用的 Monaco 编辑器灵活得多：
+
+- **JSON5 支持**：查询里可以加注释，尾随逗号不会报错。
+- **实时自动补全**：连接时直接从 Mapping 里拉字段建议。
+- **DSL 校验**：编辑器检查语法是否符合 OpenSearch Query DSL。
+- **一键导出**：保存时自动格式化，任何查询一键复制成 `curl`。
+- **多标签**：同时开多条查询，并行运行。
+- **本地历史**：完整的执行历史保存在本地，完全可搜索。
+
+## 连接 DocKit 到 OpenSearch
+
+### 自建 OpenSearch
+
+1. **[下载 DocKit](/zh/download)**。
+2. 点 **新建连接**，选 **OpenSearch**。
+3. 填入地址、端口和认证方式（Basic Auth、API Key 或无认证）。
+4. 点 **连接**。
+
+### AWS OpenSearch Service
+
+1. 点 **新建连接**，选 **OpenSearch**。
+2. 填入 Domain Endpoint（`https://...` 那段 URL）。
+3. 选 **AWS 凭证** 认证方式，DocKit 会自动读取 `~/.aws/credentials` 或环境变量。
+4. 点 **连接**。
+
+VPC 集群或细粒度访问控制，参考[连接指南](/docs/dockit/connect-to-server)。
+
+## OpenSearch 版本支持
+
+DocKit 使用标准 REST API，支持 **OpenSearch 1.x、2.x 和 3.x**。和 OpenSearch Dashboards 不同，它不与集群版本绑定。
+
+## 常见问题
+
+**DocKit 是完整的 OpenSearch Dashboards 替代方案吗？**
+在查询开发和索引管理上，是的。在大盘、可观测和告警方面，不是。大多数团队两个都用。
+
+**支持 Amazon OpenSearch Service 吗？**
+支持。DocKit 用你的 AWS 凭证连接 AWS OpenSearch Service 的 REST Endpoint。Basic Auth 适用于 HTTP 层认证；AWS SigV4 签名在路线图上，可以去 [GitHub](https://github.com/geek-fun/dockit/issues) 跟进进展。
+
+**可以在 VPN 后面的 OpenSearch 上用 DocKit 吗？**
+可以，只要 DocKit 能访问 OpenSearch REST 端口（默认 9200）就行。建好 VPN 或 SSH 隧道后，把 DocKit 指向 `localhost` 即可。
+
+**支持 OpenSearch Serverless 吗？**
+OpenSearch Serverless 要求每个请求都做 SigV4 签名，普通凭证认证不够。可以去 [GitHub Issues](https://github.com/geek-fun/dockit/issues) 了解当前进展。
+
+---
+
+→ **[DocKit 完整功能概览](/products/dockit/)** · [OpenSearch GUI 客户端页面](/products/dockit/opensearch-gui-client) · [OpenSearch GUI 深度解析](/zh/blog/opensearch-gui)


### PR DESCRIPTION
## Summary

- **ZH vs-pages** — `dockit-vs-kibana.md` and `dockit-vs-opensearch-dashboards.md` added under `docs/zh/products/dockit/`. Both include proper hreflang (en/zh/x-default), canonical, JSON-LD `SoftwareApplication`, and developer-to-developer ZH copy mirroring the EN pages.
- **Orphan feature pages linked** — `docs/products/dockit/index.md` now has a "More on DocKit" section at the bottom linking all 4 previously orphan feature pages (`desktop-client`, `dynamodb-partiql`, `local-first`, `open-source`), making them crawlable via internal links.
- **hreflang fix** — `docs/zh/blog/serverless-api-gateway-body-transform.md` was missing all `<link rel="alternate">` tags. Added en/zh/x-default hreflang to match the EN page.
- **JSON-LD date fix** — Both EN + ZH `serverless-api-gateway-body-transform.md` were missing `datePublished` and `dateModified` in the `BlogPosting` schema. Set to `2026-04-15` (first commit date).
- **Redirect destinations** — `/products.html` and `/zh/products.html` redirects now point to trailing-slash URLs (`/products/`, `/zh/products/`) matching VitePress `cleanUrls` behaviour.

## Depends on

Merge after PR #17 (`seo/p1-vs-pages`).

Related to #4