### PR TITLE
content: 5-part AI agent engineering series (EN+ZH)

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -27,6 +27,11 @@ Welcome to the **GEEKFUN Blog!** :rocket::rocket::rocket:
 
 Product updates, technical deep-dives, and lessons from building open-source database tools. Written by the GEEKFUN team.
 
+## [Engineering Production AI Agents: Architecture (Part 1 of 5)](/blog/building-ai-agent-architecture)
+*May 22, 2026*
+
+How DocKit builds a production AI agent across a Rust backend and Vue 3 frontend — streaming events over Tauri IPC, a composable orchestration layer, and clean separation between agent logic and UI state. Part 1 of a 5-part series grounded in real source code.
+
 ## [DocKit 1.0 - The NoSQL desktop client developers deserved](/blog/introducing-dockit-v1)
 *May 10, 2026*
 

--- a/docs/blog/building-ai-agent-architecture.md
+++ b/docs/blog/building-ai-agent-architecture.md
@@ -1,0 +1,155 @@
+---
+title: "Building AI Agents in Production: Architecture (Part 1)"
+description: How DocKit structures a production AI agent across a Rust backend and Vue 3 frontend, using Tauri IPC for streaming events, a composable orchestration layer, and a clean separation between agent logic and UI state.
+head:
+  - - meta
+    - name: keywords
+      content: AI agent architecture, production AI agent, Tauri AI agent, Rust AI agent, Vue 3 AI agent, LLM agent design, streaming agent, agent loop, IPC agent events, desktop AI agent
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-architecture
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Building AI Agents in Production: Architecture (Part 1)",
+        "description": "How DocKit structures a production AI agent across a Rust backend and Vue 3 frontend, using Tauri IPC for streaming events, a composable orchestration layer, and a clean separation between agent logic and UI state.",
+        "image": "https://www.geekfun.club/og/master-en.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/blog/building-ai-agent-architecture" },
+        "keywords": ["AI agent", "Tauri", "Rust", "Vue 3", "streaming LLM", "agent architecture"],
+        "articleSection": "AI Agent Engineering"
+      }
+---
+
+# Building AI Agents in Production: Architecture (Part 1)
+
+*Part 1 of 5 — [Part 2: Tool System Design](/blog/building-ai-agent-tools) · [Part 3: Permissions & Confirmation](/blog/building-ai-agent-permissions) · [Part 4: Memory & Compaction](/blog/building-ai-agent-memory) · [Part 5: Persistence & Resilience](/blog/building-ai-agent-persistence)*
+
+---
+
+Most writing about AI agents stops at the demo stage — a Python script, an OpenAI call, a streaming response. Production is different. You have a real application with users, connections to live databases, destructive operations, and a user interface that needs to feel immediate and trustworthy. This series is about what that actually looks like, drawn directly from the source code of [DocKit](https://github.com/geek-fun/dockit), an open-source AI-native NoSQL desktop client.
+
+This first part covers the hardest question you face before writing a single line of agent code: **where does the agent live, and how does it talk to everything else?**
+
+## The stack problem
+
+DocKit runs on the desktop using [Tauri](https://tauri.app/) — a framework that pairs a native Rust backend with a web-based frontend. When it came time to add an AI agent, the team faced a choice that will be familiar to anyone building agents in a non-Python app:
+
+- Put the agent logic in the frontend (TypeScript, in the browser sandbox)?
+- Or put it in the native backend (Rust, with full system access)?
+
+The answer matters more than it might seem.
+
+The frontend has convenient access to UI state and user interactions. But it runs in a sandboxed webview, can't hold persistent native resources cleanly, and would need to expose database credentials to JavaScript — a significant attack surface. More practically, streaming LLM responses with retries, assembling chunked tool calls across hundreds of SSE events, and managing concurrent database connections is exactly the kind of stateful, CPU-bound work that belongs in a native process.
+
+The Rust backend won. The agent loop, LLM client, tool executor, session persistence, token counting, and context compaction all live in Rust. The frontend does what it does best: state management, streaming UI, and user interaction.
+
+## The IPC boundary
+
+When two processes need to talk in real time, the interface design is where projects succeed or fail. DocKit uses Tauri's IPC bridge, which provides two communication primitives:
+
+**Commands** (`invoke`) are RPC calls — the frontend calls into Rust, gets a typed result back. These handle things like: start a new agent session, load conversation history, confirm a tool call, trigger a compaction.
+
+**Events** (`emit`/`listen`) are fire-and-forget from Rust to the frontend. These handle streaming: each token of the LLM's response, each tool call the agent decides to make, each tool result that comes back. The frontend registers listeners and reacts as data arrives.
+
+This asymmetry is intentional. Commands model state transitions (discrete, synchronous-ish operations where you care about success/failure). Events model streams (continuous, incremental data where each chunk updates the UI). The agent loop is fundamentally a stream, so events are its primary output channel.
+
+### The event vocabulary
+
+The full event taxonomy emitted by the agent loop covers the complete lifecycle of an interaction:
+
+- `agent-loop-delta` — a content token from the LLM's response, appended to the current assistant message
+- `agent-loop-thinking-delta` — a reasoning token, when the model supports explicit reasoning/thinking output
+- `agent-loop-tool-call` — the agent has decided to call a tool; carries tool name, arguments, and a unique call ID
+- `agent-loop-tool-result` — a tool has finished executing; carries a summary of the output and timing metadata
+- `agent-loop-step-done` — the current LLM streaming call has completed; a step may contain multiple tool calls
+- `agent-loop-done` — the entire agent loop has finished; the session returns to idle
+- `agent-loop-error` — something failed; the session transitions to error state with a message
+- `agent-context-usage` — emitted per iteration to communicate current token usage and whether compaction is needed
+
+Every state transition in the UI is driven by one of these events. There is no polling. The frontend is purely reactive.
+
+## The loop runner
+
+The heart of the agent is what DocKit calls the *loop runner* — the Rust function that orchestrates a full agent interaction from user message to final response.
+
+Think of it less like a function and more like a process: it runs up to 20 iterations, each of which involves making an LLM call, parsing the response, and then deciding what to do next. If the LLM returns a plain text reply, the loop ends. If the LLM returns tool calls — functions it wants to invoke against the database — the loop pauses, executes those tools (with user confirmation if needed), feeds the results back to the LLM, and continues.
+
+Each iteration follows a consistent sequence:
+
+1. Emit the current token usage via `agent-context-usage`
+2. Optionally run context compaction if token usage is high
+3. Load the conversation history from SQLite
+4. Construct the LLM request (messages + tool definitions)
+5. Stream the LLM response, emitting `agent-loop-delta` and `agent-loop-thinking-delta` tokens as they arrive
+6. If the response contains tool calls: persist the assistant message, process each tool call (permission checks, confirmation, execution)
+7. Persist tool results and continue to the next iteration
+8. If the response is a final reply: persist it and emit `agent-loop-done`
+
+What's worth noting here is the persistence after each step. Unlike a toy agent that keeps everything in memory, DocKit writes to SQLite at every meaningful state change. This means a crash between steps doesn't lose data, sessions can be loaded from history, and tool results are available for later inspection even if the full output was too large to show in the UI.
+
+## The frontend composable
+
+On the Vue 3 side, the agent interaction is orchestrated by a composable — `useChatAgent` — that wires all the event listeners and exposes a simple `sendMessage` interface to the UI.
+
+The composable pattern is a good fit here because it isolates all the Tauri IPC complexity from the rest of the application. The views and stores that use it don't know anything about event names or invoke commands. They get a `sendMessage` function and reactive state that updates as events arrive.
+
+When the user sends a message, the composable:
+
+1. Creates or resolves a session ID
+2. Inserts the user message into the local store immediately (no waiting for the server round-trip — the UI feels instant)
+3. Fetches the tool definitions from the backend (if the session has database connections attached)
+4. Constructs the system prompt, incorporating attached data sources, schemas, and any session-specific rules
+5. Calls `run_agent_loop` on the Rust backend with the message, settings, and connection configs
+6. From that point on, the composable is purely reactive — incoming events update the store, which updates the UI
+
+This separation is important: the composable is the only place in the frontend that knows about Tauri events. Everything above it (views, stores, other composables) works with plain Vue reactive state.
+
+### Feature adapters
+
+DocKit has two distinct agent UIs: a full-screen chat in the data studio, and a sidebar assistant accessible from any connection view. They have different contexts, different session lifecycles, and different ways of attaching database connections.
+
+Rather than building two separate agent integrations, DocKit uses a thin adapter pattern. `useDataStudioChatAgent` and `useSidebarChatAgent` each wrap `useChatAgent` with feature-specific logic: which sessions to create, what context to inject, how to surface connections. The core orchestration logic lives once, in the base composable.
+
+## Where session state lives
+
+A session in DocKit has two kinds of state, kept in different places by design:
+
+**Runtime state** (not persisted) — the tool definitions and metadata fetched at session start, the streaming assistant message being assembled from token events, the confirmation channels awaiting user input. This state is ephemeral, built fresh each time the loop runs.
+
+**Persistent state** (SQLite) — conversation messages, tool call records, tool results, session metadata. This is the durable record that can be loaded back from history, exported, or used as the basis for the next LLM call.
+
+The separation matters because it prevents stale data from persisting across sessions while ensuring nothing genuinely important gets lost.
+
+## Why this architecture works
+
+There is no novel insight in any individual piece of this design. IPC bridges, event-driven UIs, and persistent session storage are standard patterns. What makes this architecture coherent is the combination:
+
+- The agent's unsafe surface (database access, network calls, file handling) is isolated in a native process where it belongs
+- The UI is purely reactive — it can't accidentally trigger side effects; it just responds to events
+- The persistence layer is at every step, not just at the end — the system is resilient to partial failures
+- The composable abstraction prevents the Tauri implementation details from leaking into application code
+
+Part 2 of this series goes deeper into how the tool system is designed — specifically, how tools are defined as first-class data structures with risk levels and permissions, and why that metadata matters beyond just calling the right database function.
+
+---
+
+*DocKit is open source. The architecture described here lives in [`src-tauri/src/agent/`](https://github.com/geek-fun/dockit/tree/master/src-tauri/src/agent) (Rust) and [`src/composables/`](https://github.com/geek-fun/dockit/tree/master/src/composables) (Vue 3). If you're building something similar, the code is the best documentation.*

--- a/docs/blog/building-ai-agent-memory.md
+++ b/docs/blog/building-ai-agent-memory.md
@@ -1,0 +1,134 @@
+---
+title: "Building AI Agents in Production: Memory & Context Compaction (Part 4)"
+description: How DocKit manages LLM context windows with token-accurate budgeting, two-tier compaction (microcompact + LLM summary), and a model registry that knows the real usable window for every major provider.
+head:
+  - - meta
+    - name: keywords
+      content: LLM context management, agent memory management, context window compaction, token counting, context compaction, LLM context overflow, agent long context, tiktoken, context budget
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-memory
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Building AI Agents in Production: Memory & Context Compaction (Part 4)",
+        "description": "How DocKit manages LLM context windows with token-accurate budgeting, two-tier compaction (microcompact + LLM summary), and a model registry that knows the real usable window for every major provider.",
+        "image": "https://www.geekfun.club/og/master-en.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/blog/building-ai-agent-memory" },
+        "keywords": ["context management", "token counting", "LLM compaction", "agent memory", "context window"],
+        "articleSection": "AI Agent Engineering"
+      }
+---
+
+# Building AI Agents in Production: Memory & Context Compaction (Part 4)
+
+*Part 4 of 5 — [Part 1: Architecture](/blog/building-ai-agent-architecture) · [Part 2: Tool System Design](/blog/building-ai-agent-tools) · [Part 3: Permissions & Confirmation](/blog/building-ai-agent-permissions) · [Part 5: Persistence & Resilience](/blog/building-ai-agent-persistence)*
+
+---
+
+Every LLM has a context window. In a toy demo, you never hit it. In a production agent that calls tools, accumulates results, and runs across many conversation turns, you hit it constantly.
+
+When you do, the results are ugly. The API returns a 400 error. The conversation is simply truncated from the beginning, causing the LLM to lose track of earlier context without warning. Tool pairs get split — an assistant message references a tool call that no longer exists in the context, causing the LLM to hallucinate or loop.
+
+DocKit addresses this with a system built around three components: a token counter that works without the LLM's cooperation, a model registry that knows the real usable window for each provider, and a two-tier compaction strategy that manages context automatically.
+
+## Why "just count tokens" is harder than it sounds
+
+The fundamental problem with token counting across multiple LLM providers is that tokenizers aren't standardized or even publicly distributed. OpenAI publishes `tiktoken`, which gives exact BPE token counts. Anthropic does not. DeepSeek does not. If you want to count tokens for a Claude or DeepSeek conversation, you're working without an official tool.
+
+DocKit's token counter takes a pragmatic approach: use exact BPE when available, fall back to conservative heuristics when not.
+
+For OpenAI models, the system uses `tiktoken-rs` with the appropriate BPE encoding for each model family — `cl100k_base` for GPT-4 and older models, `o200k_base` for the newer o-series and GPT-4o variants. The per-message overhead constants match OpenAI's documented accounting (4 tokens per message, 3 tokens for the reply envelope), so the counts line up with what the API actually charges.
+
+For Anthropic, DeepSeek, and generic OpenAI-compatible providers, the system uses character-ratio heuristics. Anthropic uses roughly 3.5 characters per token — a number derived from analyzing typical English text through their tokenizer. DeepSeek uses 3.2, reflecting its somewhat different tokenization of code and technical content. Generic providers default to 3.3.
+
+The heuristics always round up. An overestimate of token usage means the system compacts slightly earlier than strictly necessary. An underestimate would mean trusting that you're safe when you're not, which causes the exact API errors the compaction system exists to prevent. Conservative is the right call.
+
+## The model registry
+
+Before you can reason about token budgets, you need to know each model's context window and how much of it you can actually use.
+
+These are different numbers. A model with a 128K token context window doesn't give you 128K tokens for conversation history. The model needs room to generate a response. Without an output reserve, the model might have as few as a thousand tokens of generation capacity left, producing truncated or incoherent responses.
+
+The model registry maps each supported model to three values:
+
+- **Context window** — the total input + output limit for the model
+- **Output reserve** — tokens set aside for the model's response
+- **Tokenizer family** — which counting method to use
+
+The usable window — the denominator for all compaction decisions — is simply `context_window - output_reserve`. This "usable window" is what the system actually manages.
+
+The reserves are conservative by default: 16,000 tokens for OpenAI models, 20,000 for Anthropic (where Claude's long outputs make a larger reserve appropriate), 8,000 for DeepSeek. For models where the user knows the context limit (common with locally-hosted models via Ollama or LM Studio), the registry supports a `contextWindowOverride` that lets users specify the actual configured limit.
+
+## The compaction trigger
+
+Compaction doesn't happen at the moment the context fills. It triggers proactively, at a threshold designed to leave enough room for the current operation to complete.
+
+The trigger is calculated as the minimum of two values: 75% of the usable window, and the usable window minus 13,000 tokens as a safety buffer. The dual formula handles edge cases: for models with very large context windows, the 75% ratio triggers early enough to leave room. For smaller models where the absolute safety buffer matters more, the subtraction term kicks in.
+
+The 13,000-token safety buffer is sized to accommodate a typical agent step: an LLM response with reasoning, a few tool calls and their results, and the model's output. This ensures compaction never triggers so late that the next step has nowhere to operate.
+
+## Two-tier compaction
+
+When the trigger fires, the system attempts two levels of compaction in sequence, choosing the cheapest approach that solves the problem.
+
+### Tier 1: Microcompaction
+
+The first tier is local and cheap — no LLM call required.
+
+The insight: in long agent conversations, the content that fills the context is usually tool results. A sequence of search results, document fetches, or query outputs can easily consume tens of thousands of tokens. Most of that detail isn't needed once the immediate task has moved past it. The agent already processed those results; the LLM doesn't need to re-read them.
+
+Microcompaction walks the message history and looks for tool messages (the assistant-side records of tool results) older than the most recent four user/assistant exchanges. For any tool message whose content exceeds 800 characters, it truncates the content to the first 800 characters and appends a note explaining that the rest was elided.
+
+This operation preserves the conversation structure entirely. Every message still exists. Tool call IDs still match their results. The LLM's access to recent context is unchanged. Only the body of older tool results is shortened.
+
+For many sessions, microcompaction is enough. A session that's been running for a while and has accumulated tool results from earlier in the conversation can often be brought back under the trigger threshold by this simple pass.
+
+### Tier 2: LLM summary compaction
+
+If microcompaction isn't sufficient, the system escalates to a full LLM-based summarization.
+
+This is the expensive path. It requires an additional LLM call and introduces a delay. But it achieves much higher compression — entire swaths of the conversation history can be replaced with a structured summary that preserves the operational context the agent needs.
+
+The process works as follows:
+
+**Safe splitting.** The system identifies a split point in the conversation history, keeping the most recent four message pairs intact and summarizing everything older. The split is carefully chosen to avoid breaking tool call pairs — an assistant message that includes tool calls must not be separated from the tool result messages that follow it. If a naive split would create an orphan, the split point moves earlier.
+
+**Orphan tracking.** If the split would leave tool calls without their results (because the result falls within the kept window but the assistant message requesting them falls in the summarized prefix), those tool call IDs are collected and preserved separately. This ensures the LLM can reason about in-flight tool calls correctly even after compaction.
+
+**Structured summarization.** The prefix to be compacted is passed to the LLM with a strict system prompt that requests a summary in nine sections: primary intent, key technical concepts, files and code touched, errors and fixes attempted, a tight per-message summary of every user turn, pending tasks, current work state, the immediate next step, and the list of preserved tool call IDs. This structure is intentional — it forces the summary to preserve the information an agent actually needs to continue working, rather than producing a free-form summary that might omit critical details.
+
+**Boundary marker.** The summarized prefix is replaced by a single system message containing the summary text, the token counts before and after compaction, and the list of preserved tool call IDs. A special marker (`_compact_boundary`) flags this message so the session store can normalize it for display — users see a readable summary in the chat history rather than raw JSON.
+
+## The result
+
+The compaction system means DocKit agent sessions can run indefinitely without hitting context limits — or at least as long as there's meaningful state to compress. In practice, sessions that involve long sequences of tool calls (browsing an index, running multiple queries, iterating on a schema problem) stay functional for hundreds of turns.
+
+The UI surfaces this with a token usage indicator that shows current usage against the model's capacity, with color thresholds at 60% (amber warning) and 80% (red, pulsing). Users can see the agent's "memory pressure" in real time and trigger manual compaction if they want to reclaim context space.
+
+The combination of proactive budgeting, conservative token counting, cheap local compaction as the first resort, and expensive LLM summarization as the fallback gives the system good latency characteristics in the common case and correct behavior in the worst case.
+
+Part 5 wraps up the series by looking at what happens when things go wrong — retry strategies, error classification, the SQLite persistence layer, and how the system surfaces failures clearly enough that users can recover rather than just seeing a generic error.
+
+---
+
+*The compaction system lives in [`src-tauri/src/agent/compact.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/compact.rs), token counting in [`src-tauri/src/agent/token_counter.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/token_counter.rs), and the model registry in [`src-tauri/src/agent/model_registry.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/model_registry.rs).*

--- a/docs/blog/building-ai-agent-permissions.md
+++ b/docs/blog/building-ai-agent-permissions.md
@@ -1,0 +1,143 @@
+---
+title: "Building AI Agents in Production: Permissions & Confirmation (Part 3)"
+description: How DocKit implements a layered permission model for AI agents — session-level modes, per-connection permissions, risk-based confirmation, and persistent allow/deny rules that reduce friction without removing safety.
+head:
+  - - meta
+    - name: keywords
+      content: AI agent permissions, agent confirmation flow, human-in-the-loop AI, AI agent safety, LLM tool confirmation, agent permission model, AI agent UX, oneshot channel confirmation
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-permissions
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Building AI Agents in Production: Permissions & Confirmation (Part 3)",
+        "description": "How DocKit implements a layered permission model for AI agents — session-level modes, per-connection permissions, risk-based confirmation, and persistent allow/deny rules that reduce friction without removing safety.",
+        "image": "https://www.geekfun.club/og/master-en.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/blog/building-ai-agent-permissions" },
+        "keywords": ["AI agent permissions", "human-in-the-loop", "confirmation flow", "agent safety", "permission model"],
+        "articleSection": "AI Agent Engineering"
+      }
+---
+
+# Building AI Agents in Production: Permissions & Confirmation (Part 3)
+
+*Part 3 of 5 — [Part 1: Architecture](/blog/building-ai-agent-architecture) · [Part 2: Tool System Design](/blog/building-ai-agent-tools) · [Part 4: Memory & Compaction](/blog/building-ai-agent-memory) · [Part 5: Persistence & Resilience](/blog/building-ai-agent-persistence)*
+
+---
+
+The hardest UX problem in agents that operate on real systems isn't the AI part. It's the trust part.
+
+If every action requires manual approval, the agent is useless — you're doing the work yourself, just through a worse interface. If every action is automatic, you've handed an LLM the keys to your production database. Neither extreme works for real users on real systems.
+
+DocKit's permission model is an attempt to find that balance. It uses four independent policy layers that combine at runtime to decide whether a specific tool call should proceed automatically or wait for human confirmation. This post explains how those layers work and why they're designed the way they are.
+
+## What a session knows about its connections
+
+When a user attaches a database connection to an agent session, DocKit takes a snapshot — not a live reference. The snapshot freezes the connection's alias, type, and permissions at the moment of attachment. If the connection configuration changes later (a password rotation, a permissions update), the running session is unaffected until it's explicitly restarted with the new config.
+
+This is a deliberate safety choice. A live reference means the session's capabilities could change underneath it mid-conversation, which is hard to reason about and potentially dangerous. A frozen snapshot means the session operates within a known, stable set of capabilities for its entire lifetime.
+
+Each connection snapshot carries a permissions map: a set of boolean flags for `read`, `create`, `update`, and `delete`. These flags define what operations are possible on that connection — not just what the agent is allowed to request, but what will physically execute.
+
+## The four policy layers
+
+### Layer 1: The session allow-list
+
+The allow-list is the outermost ring. When a session starts, it can be configured with a specific set of tool names the agent is allowed to call. Any tool not on that list is rejected before permissions or confirmation logic even runs.
+
+This layer is coarse and absolute. It's useful for creating intentionally limited sessions — a "read-only analysis" session that can access all the read tools but none of the write tools, regardless of what any connection permits.
+
+### Layer 2: Per-connection required permissions
+
+For any tool that passes the allow-list, the system looks up the tool's `required_permission` (from the tool registry described in Part 2) and checks whether the attached connection grants that permission.
+
+The check runs in Rust, inside the loop runner, before any database call is made. The UI has no mechanism to bypass it. This is important because it means permission enforcement is not a frontend policy that can be circumvented — it's a backend invariant.
+
+The practical use: connect a read replica to the session and grant it only `read` permission. Any tool that requires `create`, `update`, or `delete` will fail this check regardless of everything else — even if the user's auto mode is on, even if there's an "allow always" rule for that tool. The connection permission is a hard floor.
+
+### Layer 3: Session-level permission mode
+
+Above the per-connection permissions, sessions have a mode: `Ask` or `Auto`.
+
+In `Ask` mode (the default), elevated-risk tools require explicit user confirmation even when the connection grants the required permission. In `Auto` mode, elevated-risk tools proceed without confirmation — only destructive-risk tools still require it.
+
+This mode can be set at the session level (applying to all connections) or per-connection. A session might run in `Auto` mode for the read replica (where the worst case is a slow query) but stay in `Ask` mode for the primary connection where writes happen.
+
+The mode switch is a deliberate friction control. Users who know what they're doing and have vetted their connections can reduce interruptions. Users who want to stay in the loop can require confirmation for anything above read.
+
+### Layer 4: Persistent confirmation rules
+
+The finest-grained layer is confirmation rules — persistent, session-scoped records that say "for this session, always allow tool X" or "for this session, always deny tool Y."
+
+Rules survive session restarts (they're persisted in the frontend store). Once a user decides to "allow always" for `es__search` in a particular session, they won't be asked about it again in that session. Same for denials: "deny always" for `es__delete_by_query` means that tool is blocked regardless of mode or permissions.
+
+The rules are checked before risk-level and mode logic. A matching rule short-circuits the entire confirmation decision: allow always means the tool proceeds immediately, deny always means it fails immediately, with no UI prompt.
+
+## The confirmation handshake
+
+When a tool call does require confirmation, the mechanics of how that decision travels from the UI back to the running backend are worth understanding.
+
+The loop runner, running asynchronously in Rust, creates a oneshot channel for the tool call. The sender end is placed in a global `ConfirmMap`, keyed by the tool call ID. The loop runner then awaits the receiver — it's suspended, not spinning, consuming no CPU while it waits.
+
+In the UI, the user sees the tool call with its arguments and risk level. They make a decision. The frontend calls a Tauri command with the tool call ID and their decision (approve or deny). On the Rust side, that command looks up the sender in the `ConfirmMap`, sends the boolean, and removes the entry.
+
+The loop runner's await resolves. If approved, it proceeds to execute the tool. If denied, it inserts a failure message into the conversation and continues the loop — the LLM learns the tool was denied and can adapt its plan.
+
+A few implementation details worth noting:
+
+**The entry is cleaned up on drop.** A `ConfirmGuard` wraps the ConfirmMap entry and removes it when dropped, regardless of how the loop runner exits. This prevents the map from accumulating stale entries if the session errors out or is cancelled mid-confirmation.
+
+**The timeout is five minutes.** If no decision arrives, the confirmation times out and the session fails with a clear error message. This prevents sessions from hanging indefinitely if the user closes the window or forgets about a pending confirmation.
+
+**Immediate confirmations for auto-allowed tools.** When a tool doesn't require confirmation (safe risk level, auto mode, or allow-always rule), the frontend immediately calls the confirm command with `approved = true` without waiting for user input. From the backend's perspective, all tool calls look the same — they wait for a confirmation signal. The decision about whether to show a UI prompt happens entirely in the frontend, and the backend doesn't need to know.
+
+## The confirmation decision tree
+
+When `onAgentLoopToolCall` arrives in the frontend, the composable walks through this priority order:
+
+1. Is there a session rule that says **deny always** for this tool? → Deny immediately, no UI prompt
+2. Is there a session rule that says **allow always** for this tool? → Approve immediately, no UI prompt
+3. Is the risk level **Safe**? → Approve immediately, no UI prompt
+4. Is the risk level **Destructive**? → Always show confirmation, regardless of mode
+5. Is the session in **Auto** mode? → Approve immediately, no UI prompt
+6. Otherwise (Elevated risk, Ask mode) → Show confirmation prompt
+
+This ordered evaluation means the most specific signal wins. A session rule always beats the mode setting, which always beats the default risk behavior. Users can build confidence in specific tools over time (adding allow-always rules) without disabling safety for new, unfamiliar tools.
+
+## Why this design ages well
+
+The layered model separates concerns that would otherwise become tangled as the system grows:
+
+Adding a new tool doesn't require updating permission logic — the tool declares its own risk level and required permission, and the existing rules apply automatically.
+
+Supporting a new database type doesn't require new confirmation code — the permission check is against a generic permission key (`create`, `update`, etc.), not a database-specific concept.
+
+Users who want tighter control can tighten individual layers (restrict the allow-list, stay in Ask mode, add deny rules) without affecting users who want looser operation. The system is as cautious as you need it to be and as fluid as you can trust it to be.
+
+The one thing this model doesn't yet solve well is cross-session rule sharing. Rules are scoped to a session, which is the right default for isolation. But experienced users working across many sessions might want global "always allow read-only tools" rules. That's a natural evolution of this design.
+
+Part 4 takes a different direction — away from safety and toward the engineering problem that breaks the most production agents: the context window. Once your agent runs long conversations, token budgets fill up, and without a compaction strategy, the agent stops working. DocKit's solution involves two tiers of compaction, a custom token counting layer, and a model registry that knows about every major LLM provider's context limits.
+
+---
+
+*The confirmation logic lives in [`src/composables/useChatAgent.ts`](https://github.com/geek-fun/dockit/blob/master/src/composables/useChatAgent.ts). The backend confirmation channels are in [`src-tauri/src/agent/loop_runner.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/loop_runner.rs).*

--- a/docs/blog/building-ai-agent-persistence.md
+++ b/docs/blog/building-ai-agent-persistence.md
@@ -1,0 +1,132 @@
+---
+title: "Building AI Agents in Production: Persistence & Resilience (Part 5)"
+description: How DocKit handles failure gracefully — retry with jitter, error classification, SQLite-backed session persistence, the ToolEnvelope audit trail, and provider normalization across OpenAI, Anthropic, DeepSeek, and local models.
+head:
+  - - meta
+    - name: keywords
+      content: AI agent resilience, LLM retry strategy, agent error handling, agent session persistence, SQLite agent storage, LLM provider normalization, agent observability, streaming LLM errors
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-persistence
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Building AI Agents in Production: Persistence & Resilience (Part 5)",
+        "description": "How DocKit handles failure gracefully — retry with jitter, error classification, SQLite-backed session persistence, the ToolEnvelope audit trail, and provider normalization across OpenAI, Anthropic, DeepSeek, and local models.",
+        "image": "https://www.geekfun.club/og/master-en.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/blog/building-ai-agent-persistence" },
+        "keywords": ["agent resilience", "retry strategy", "session persistence", "SQLite", "error handling", "LLM providers"],
+        "articleSection": "AI Agent Engineering"
+      }
+---
+
+# Building AI Agents in Production: Persistence & Resilience (Part 5)
+
+*Part 5 of 5 — [Part 1: Architecture](/blog/building-ai-agent-architecture) · [Part 2: Tool System Design](/blog/building-ai-agent-tools) · [Part 3: Permissions & Confirmation](/blog/building-ai-agent-permissions) · [Part 4: Memory & Compaction](/blog/building-ai-agent-memory)*
+
+---
+
+Production systems fail. Networks time out, API rate limits kick in, database connections drop, and occasionally the LLM just returns something malformed. An agent that can't recover from these conditions gracefully isn't ready for real use.
+
+This final part covers how DocKit handles failure at every layer of the agent stack — from LLM request retries to tool output truncation to session export and import. These aren't the most intellectually interesting parts of an agent. They're the parts that determine whether users trust it.
+
+## The LLM streaming problem
+
+Streaming responses from LLMs introduce a class of failure mode that batch APIs don't have: the stream can fail partway through.
+
+You've received the beginning of the assistant's message. You've been emitting delta events to the UI. The user can see partial text building up. Then the connection drops, or the API returns an error mid-stream, or the model hits a safety filter after generating half a response.
+
+DocKit's streaming client handles this with a retry schedule: on a retriable error, it waits 1 second, then 3 seconds, then 8 seconds, with a ±250ms jitter applied to each delay. The jitter prevents the thundering herd problem — if you have many users hitting a rate limit simultaneously, random jitter staggers their retries so they don't all hammer the API at the same moment.
+
+Not all errors are worth retrying. Retrying a malformed request wastes time and money. The system classifies errors by reading the JSON body of the API error response and extracting the `error.type` field. The retryable types are: `rate_limit_exceeded`, `insufficient_quota`, `service_unavailable`, and `overloaded_error`. HTTP 429 and 503 status codes are also treated as retriable.
+
+Everything else — bad requests, authentication failures, invalid model names — fails immediately. These are problems the user needs to fix, not transient conditions worth waiting on.
+
+When a streaming request ultimately fails after all retries, the error is surfaced as an `agent-loop-error` event. The UI shows the exact error message rather than a generic failure notification. For rate limit errors, users see they've exceeded their quota. For authentication errors, they see that their API key is invalid. The agent doesn't hide the cause.
+
+One additional care: API keys are scrubbed from error messages before they're emitted to the UI. An error message that leaks credentials in the response body gets its key value redacted before the user sees it.
+
+## Persistence at every step
+
+The most common mistake in agent implementations is treating persistence as an afterthought — something that happens at the end of a successful session. If the agent crashes or the user closes the window mid-conversation, everything is lost.
+
+DocKit writes to SQLite at every significant state transition:
+
+**After the user sends a message** — the user message is persisted before the LLM is even called. If the session errors out on the first attempt, the user's message is still there when they come back.
+
+**After the LLM responds** — the assistant message (including any tool calls the LLM decided to make, stored as structured JSON) is persisted before any tool execution begins. If tool execution fails, the session history still shows the LLM's intent.
+
+**After each tool call result** — the result envelope is written to its own table (`tool_result_store`) along with the full output. The conversation history record references this by ID rather than embedding the full result inline — which keeps the main messages table from bloating with large query outputs.
+
+**On status changes** — session status transitions (`idle`, `running`, `waiting_confirmation`, `error`) are persisted so that if the application restarts, sessions can be restored to their last known state.
+
+This step-by-step persistence model means that session history is always a faithful record of what happened, not a reconstructed approximation.
+
+### The full result store
+
+The two-level output design from Part 2 (summary for the LLM, full result for storage) maps directly to how results are stored.
+
+The `tool_result_store` table holds the complete tool output, truncated only to prevent genuinely pathological cases (32,000 character limit). The main conversation history holds the summary (approximately 1,000 characters). The UI shows the summary by default; users can request the full result when they need it.
+
+This design has a subtle benefit for long sessions: the compaction system described in Part 4 can elide the content of old tool messages in the conversation history without losing data. The full results are still in `tool_result_store`, accessible on demand, even if the microcompaction pass has trimmed the conversation record to just the first 800 characters.
+
+## Provider normalization
+
+DocKit supports six LLM provider families: OpenAI, Anthropic (via OpenAI-compatible proxies), DeepSeek, OpenRouter, Ollama, and LM Studio. Each has slightly different base URLs, slightly different response shapes, and in some cases different streaming formats.
+
+The provider normalization layer (`harness.rs`) handles this translation. Every provider gets mapped to a normalized base URL — `/v1` is added if missing, trailing slashes are handled consistently. Model listing uses per-provider logic because response shapes differ: OpenAI returns `{ data: [{ id }] }`, while Ollama and LM Studio return model lists in different formats.
+
+For streaming specifically, the harness assembles tool calls from fragmented chunks. The LLM streams tool calls incrementally — function name in one chunk, partial arguments in the next, more arguments in the one after. The harness uses the `index` field in each chunk to route fragments to the correct accumulator, concatenating argument strings until the stream ends. A naive implementation that assumes tool call data arrives in one piece will fail on any non-trivial tool call.
+
+This normalization means the agent loop itself is provider-agnostic. It sends a request to the harness and receives back assembled content, thinking deltas, and complete tool calls. Whether the underlying provider is GPT-4o, Claude, DeepSeek, or a local Ollama model is invisible above the harness layer.
+
+## Session export and import
+
+Persistent sessions create an opportunity: if you've solved a complex problem across a long conversation, that conversation is valuable. It can be shared, used as training data, or archived for compliance.
+
+DocKit implements session export and import at the SQLite level. Export walks the session's messages and tool calls, serializes them to a portable format, and returns the result. Import reconstructs the session from that format into a new local database.
+
+The import path runs the same normalization that the regular load path runs — specifically, it unwraps `_compact_boundary` markers into human-readable summary text. An exported session that has been through compaction will, on import, show readable summaries in the conversation history rather than raw JSON artifacts.
+
+## What operational resilience actually looks like
+
+It's worth stepping back from the individual mechanisms to describe what the system feels like to use when things go wrong.
+
+Rate limit during a tool call sequence: the user sees the current tool call pause, a brief wait (visible as no new events), and then the operation continuing. If the rate limit persists through all retries, they see a clear message: "rate limit exceeded." They can wait and retry, or switch to a different provider.
+
+Application crash mid-conversation: on restart, the session loads from SQLite. Messages are there. Tool call records are there. The session status may be stale (`running` when it should be `idle`), but the user can see where the conversation ended and continue from that point.
+
+Tool execution error: the error is persisted as a tool message in the conversation. The LLM sees the error in the next turn and can try a different approach. The user sees the error inline in the chat with the exact message, not a generic failure notification.
+
+Context window overflow: proactive compaction means users usually don't see this at all. When compaction does run, the UI shows a compact boundary marker in the conversation history and updates the token usage indicator. The session continues without interruption.
+
+## What this series covers
+
+These five posts have walked through every major subsystem of DocKit's agent implementation: the architecture split between Rust and Vue, the tool system with its risk levels and permissions, the layered confirmation model, context compaction and token budgeting, and finally persistence and error handling.
+
+The common thread across all of them is that production agents require more engineering than demos. A demo proves the concept. A production agent needs to handle the thousand ways reality diverges from the happy path.
+
+DocKit is open source — the full implementation is available to read, fork, and adapt. If you're building something similar, the code will answer questions this series couldn't fit.
+
+---
+
+*Session persistence lives in [`src-tauri/src/agent/session_store.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/session_store.rs). The streaming client and provider normalization are in [`src-tauri/src/agent/harness.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/harness.rs).*

--- a/docs/blog/building-ai-agent-tools.md
+++ b/docs/blog/building-ai-agent-tools.md
@@ -1,0 +1,180 @@
+---
+title: "Building AI Agents in Production: Tool System Design (Part 2)"
+description: How DocKit defines tools as first-class data structures with risk levels and required permissions, why the ToolExecutor trait matters for testability, and the three gates every tool call passes before execution.
+head:
+  - - meta
+    - name: keywords
+      content: AI agent tools, LLM function calling, tool system design, agent tool permissions, risk level classification, ToolExecutor pattern, agent safety, Rust LLM tools
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-tools
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Building AI Agents in Production: Tool System Design (Part 2)",
+        "description": "How DocKit defines tools as first-class data structures with risk levels and required permissions, why the ToolExecutor trait matters for testability, and the three gates every tool call passes before execution.",
+        "image": "https://www.geekfun.club/og/master-en.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/blog/building-ai-agent-tools" },
+        "keywords": ["AI agent tools", "function calling", "tool permissions", "risk level", "ToolExecutor", "agent safety"],
+        "articleSection": "AI Agent Engineering"
+      }
+---
+
+# Building AI Agents in Production: Tool System Design (Part 2)
+
+*Part 2 of 5 — [Part 1: Architecture](/blog/building-ai-agent-architecture) · [Part 3: Permissions & Confirmation](/blog/building-ai-agent-permissions) · [Part 4: Memory & Compaction](/blog/building-ai-agent-memory) · [Part 5: Persistence & Resilience](/blog/building-ai-agent-persistence)*
+
+---
+
+When people talk about "tool use" in AI agents, the conversation usually stops at the API level: you pass a JSON schema to the LLM, it returns a function name and arguments, you call the function. That part is easy. The hard part — the part that matters for production — is what happens before and after that call.
+
+Before: does this agent have permission to call this tool at all? Is this the kind of operation that should happen automatically, or should a human confirm it first?
+
+After: was the output truncated? What does the LLM actually see versus what gets stored? If it fails, what does the user see?
+
+DocKit's tool system answers all of these questions with a consistent design. This post is about that design.
+
+## Tools are data, not just functions
+
+The first design decision worth understanding: in DocKit, a tool is not just a function to call. It's a record with metadata that the entire system reasons about:
+
+- **Name** — the function identifier the LLM uses (e.g., `es__search`, `dynamo__delete_many`)
+- **Parameters** — a JSON schema describing the expected arguments, used both to generate the LLM prompt and to validate incoming calls
+- **Risk level** — one of `Safe`, `Elevated`, or `Destructive`, reflecting the potential impact of the operation
+- **Required permission** — a string key (`read`, `create`, `update`, `delete`) that must be present in the connection's permission config before the tool can execute
+
+This metadata lives in a central tool registry and gets serialized into OpenAI-compatible function specs when the agent loop starts. The UI fetches this metadata too — it uses `riskLevel` to decide whether to show a confirmation prompt, and displays it visually so users understand what the agent is about to do.
+
+### The tool catalog
+
+DocKit ships with 18 built-in tools spanning Elasticsearch, DynamoDB, and MongoDB:
+
+| Tool | Risk | Permission |
+|------|------|-----------|
+| `es__search` | Safe | read |
+| `es__get_document` | Safe | read |
+| `es__cat_indices` | Safe | read |
+| `es__get_mapping` | Safe | read |
+| `es__index_document` | Elevated | create |
+| `es__update_document` | Elevated | update |
+| `es__delete_document` | Destructive | delete |
+| `es__delete_by_query` | Destructive | delete |
+| `dynamo__execute_query` | Safe | read |
+| `dynamo__describe_table` | Safe | read |
+| `dynamo__execute_write` | Elevated | create |
+| `dynamo__execute_delete` | Destructive | delete |
+| `mongo__find` | Safe | read |
+| `mongo__list_collections` | Safe | read |
+| `mongo__aggregate` | Elevated | read |
+| `mongo__insert_one` | Elevated | create |
+| `mongo__update_many` | Elevated | update |
+| `mongo__delete_many` | Destructive | delete |
+
+The naming convention is intentional: `<engine>__<operation>`. This prefix-based naming makes it trivial to route tool calls to the correct executor at runtime and makes the capabilities of a session immediately legible to operators.
+
+## Three gates before execution
+
+Every tool call the LLM requests must pass three sequential checks before any code runs against a database.
+
+### Gate 1: The session allow-list
+
+When a user starts an agent session, they can configure which tools are available. This is a session-level allow-list — a whitelist of function names the agent is permitted to call. If the LLM requests a tool that isn't on the list, the call is immediately rejected with a descriptive error message that gets fed back into the conversation.
+
+The practical effect: you can run a read-only session even if your connection technically has write permissions. You can expose only the Elasticsearch tools even if DynamoDB is connected. The allow-list is a coarse capability control at the session boundary.
+
+### Gate 2: Per-connection permission checks
+
+Each database connection attached to a session carries a permissions object — a map declaring which operations (`read`, `create`, `update`, `delete`) are allowed on that connection. When a tool call arrives, the loop runner looks up the `required_permission` for that tool and checks whether the connection grants it.
+
+This check happens inside the Rust backend, not in the UI. The frontend has no way to bypass it.
+
+The design consequence is important: you can attach a read-only replica connection to a session and guarantee no write will ever reach it — regardless of what the LLM requests, regardless of what the user configured in the UI. The permission check is enforced at the execution layer, not at the policy layer.
+
+### Gate 3: User confirmation
+
+The third gate is human. For tools above a certain risk threshold, the loop runner creates a confirmation channel — a oneshot channel in Rust terms — and waits for a user decision before proceeding.
+
+The LLM knows a tool call is pending. The UI shows the call with its arguments and asks the user to approve or deny. When the user decides, the frontend invokes a Tauri command that resolves the channel, and the loop runner continues.
+
+The confirmation timeout is five minutes. If no decision arrives, the tool call fails with a timeout error. This prevents sessions from hanging indefinitely if the user walks away.
+
+## The ToolExecutor abstraction
+
+The loop runner doesn't call database functions directly. It delegates to a `ToolExecutor` trait — an abstraction that takes a tool name and parsed arguments and returns a `ToolEnvelope`.
+
+This indirection is worth understanding because it's not just about clean code. It means:
+
+**The agent logic is testable without real databases.** You can swap in a mock executor that returns canned results and test the full loop runner — streaming parsing, confirmation flows, retry logic — without any network calls.
+
+**The execution surface is bounded.** The trait defines exactly what the executor can do. There's no way for the agent loop to accidentally call something outside the executor's contract.
+
+**New database support doesn't touch the orchestration code.** Adding MongoDB tool support meant adding implementations to the executor, not modifying how confirmations work or how events are emitted.
+
+The concrete executor (`DocKitToolExecutor`) routes tool calls by name prefix to per-engine execution functions. Each engine has its own authentication, connection building, validation, and result formatting.
+
+## Input validation before execution
+
+Each tool has its own validation logic that runs before any database call:
+
+For Elasticsearch, index names are validated against a strict character allowlist — no path traversal characters, no names exceeding 255 bytes, no names that could be interpreted as configuration or metadata indices. The validation is explicit and rejects ambiguous inputs rather than trying to sanitize them.
+
+For DynamoDB, the write and delete tools validate the PartiQL statements they receive. The read tool rejects statements containing mutation verbs. The write tool rejects statements that look like bulk deletes. The delete tool only accepts DELETE statements. This ensures the risk level classification is actually enforced at the query level — the LLM can't work around a `dynamo__execute_query` permission by embedding an INSERT in the PartiQL.
+
+For MongoDB, connection string construction validates authentication config and enforces TLS settings from the connection config rather than trusting the LLM-provided arguments.
+
+## The output envelope
+
+When a tool executes successfully, the result is wrapped in a `ToolEnvelope` before it goes anywhere:
+
+```
+ToolEnvelope {
+  summary:   first ~1,000 characters of the result
+  full_result: result truncated to ~32,000 characters
+  metadata: {
+    tool_name,
+    duration_ms,
+    truncated: bool
+  }
+}
+```
+
+The envelope serves two audiences with different needs. The LLM sees the summary — enough context to understand what happened and decide what to do next, but bounded in size to avoid burning the entire context window on a single tool result. The user (via the UI) can request the `full_result` to inspect the complete output.
+
+The `truncated` flag is surfaced in the UI so the user knows they're looking at a partial result. If they need the full data, they can re-run the query directly in the editor.
+
+This two-level output design is one of the most practical decisions in the system. Without it, a tool that returns a large dataset could consume most of the context window in a single step, leaving insufficient space for the rest of the conversation. With it, the agent stays functional even when operating on large indices.
+
+## What this means for your own agent
+
+The patterns here compose into a coherent safety model:
+
+Tools defined as data — not as code spread across the codebase — means the security properties of the system are auditable. You can look at the tool catalog and immediately understand what the agent can and can't do.
+
+Three explicit gates — allow-list, permission check, user confirmation — create defense in depth. Any single gate failing (misconfigured permissions, UI bug, policy oversight) doesn't bypass the others.
+
+The executor abstraction keeps the dangerous code — actual database calls — isolated and testable independent of the orchestration logic that triggers it.
+
+Part 3 of this series goes deeper into the confirmation system: how the frontend confirmation UI interacts with the backend's oneshot channels, how session-level permission modes work, and how "allow always" and "deny always" rules let users build trust with the agent over time without disabling safety checks entirely.
+
+---
+
+*The tool registry lives in [`src-tauri/src/agent/tools.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/tools.rs). The executor is in [`src-tauri/src/agent/executor.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/executor.rs).*

--- a/docs/zh/blog.md
+++ b/docs/zh/blog.md
@@ -27,6 +27,11 @@ head:
 
 产品更新、技术深度解析，以及来自 GEEKFUN 团队构建开源数据库工具的实践记录。
 
+## [生产级 AI Agent 工程实践：架构设计（第一篇，共五篇）](/zh/blog/building-ai-agent-architecture)
+*2026年5月22日*
+
+DocKit 如何在 Rust 后端与 Vue 3 前端之间构建生产级 AI Agent——通过 Tauri IPC 实现流式事件传输、可组合的编排层，以及 Agent 逻辑与 UI 状态的清晰分离。五篇系列第一篇，基于真实源代码。
+
 ## [DocKit 1.0 - 开发者早该拥有的 NoSQL 桌面客户端](/zh/blog/introducing-dockit-v1)
 *2026年5月10日*
 

--- a/docs/zh/blog/building-ai-agent-architecture.md
+++ b/docs/zh/blog/building-ai-agent-architecture.md
@@ -1,0 +1,158 @@
+---
+title: "生产级 AI Agent 工程实践：架构设计（第一篇）"
+description: DocKit 如何在 Rust 后端与 Vue 3 前端之间构建生产级 AI Agent——通过 Tauri IPC 实现流式事件传输、可组合的编排层，以及 Agent 逻辑与 UI 状态的清晰分离。
+head:
+  - - meta
+    - name: keywords
+      content: AI Agent 架构, 生产级 AI Agent, Tauri AI Agent, Rust AI Agent, Vue 3 AI Agent, LLM Agent 设计, 流式 Agent, Agent 循环, IPC Agent 事件, 桌面 AI Agent
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-architecture
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-architecture
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "生产级 AI Agent 工程实践：架构设计（第一篇）",
+        "description": "DocKit 如何在 Rust 后端与 Vue 3 前端之间构建生产级 AI Agent，通过 Tauri IPC 实现流式事件、可组合编排层与清晰的状态分离。",
+        "image": "https://www.geekfun.club/og/master-zh.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "inLanguage": "zh-CN",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/zh/blog/building-ai-agent-architecture" },
+        "keywords": ["AI Agent", "Tauri", "Rust", "Vue 3", "流式 LLM", "Agent 架构"],
+        "articleSection": "AI Agent 工程"
+      }
+---
+
+# 生产级 AI Agent 工程实践：架构设计（第一篇）
+
+*第一篇，共五篇 — [第二篇：工具系统设计](/zh/blog/building-ai-agent-tools) · [第三篇：权限与确认](/zh/blog/building-ai-agent-permissions) · [第四篇：内存与上下文压缩](/zh/blog/building-ai-agent-memory) · [第五篇：持久化与容错](/zh/blog/building-ai-agent-persistence)*
+
+---
+
+关于 AI Agent 的文章大多止步于 Demo 阶段——一段 Python 脚本、一次 OpenAI 调用、一条流式响应。生产环境则完全不同：你面对的是真实用户、连接着生产数据库的实时系统、可能造成数据丢失的破坏性操作，以及必须让用户感到即时且可信的界面。
+
+这个系列直接基于开源项目 [DocKit](https://github.com/geek-fun/dockit)（一款 AI 原生的 NoSQL 桌面客户端）的源代码，讲述生产级 Agent 的真实工程实践。
+
+第一篇解决的是在写任何 Agent 代码之前都必须回答的最难问题：**Agent 住在哪里，以及它如何与其他一切通信？**
+
+## 栈的选择问题
+
+DocKit 基于 [Tauri](https://tauri.app/) 运行在桌面端——这个框架将原生 Rust 后端与基于 Web 的前端配对。在引入 AI Agent 时，团队面临一个任何在非 Python 应用中构建 Agent 的人都会遇到的抉择：
+
+- 把 Agent 逻辑放在前端（TypeScript，浏览器沙箱中）？
+- 还是放在原生后端（Rust，拥有完整系统访问权限）？
+
+这个选择比表面上看起来重要得多。
+
+前端可以方便地访问 UI 状态和用户交互，但它运行在沙箱化的 WebView 中，无法干净地持有原生持久资源，而且需要将数据库凭证暴露给 JavaScript——这是一个显著的攻击面。更实际的是，带重试的 LLM 流式响应、在数百个 SSE 事件中拼装分块的工具调用、管理并发数据库连接——这类有状态的、CPU 密集型工作本就属于原生进程。
+
+Rust 后端胜出。Agent 循环、LLM 客户端、工具执行器、会话持久化、Token 计数、上下文压缩——全部在 Rust 中。前端做它最擅长的事：状态管理、流式 UI、用户交互。
+
+## IPC 边界
+
+当两个进程需要实时通信时，接口设计决定成败。DocKit 使用 Tauri 的 IPC 桥接，提供两种通信原语：
+
+**命令**（`invoke`）是 RPC 调用——前端调用 Rust，得到一个类型化的结果。这处理了离散操作：启动新的 Agent 会话、加载对话历史、确认一次工具调用、触发上下文压缩。
+
+**事件**（`emit`/`listen`）是从 Rust 到前端的单向推送。这处理了流：LLM 响应的每一个 Token、Agent 决定发起的每一次工具调用、每一个返回的工具结果。前端注册监听器，随着数据到来做出响应。
+
+这种不对称性是刻意的。命令对应状态转换（离散的、关心成功/失败的操作）。事件对应流（连续的、每个数据块都要更新 UI 的场景）。Agent 循环本质上是一个流，所以事件是其主要输出通道。
+
+### 事件词汇表
+
+Agent 循环发出的完整事件覆盖了一次交互的完整生命周期：
+
+- `agent-loop-delta` — LLM 响应中的一个内容 Token，追加到当前助手消息
+- `agent-loop-thinking-delta` — 推理 Token（当模型支持显式推理/思考输出时）
+- `agent-loop-tool-call` — Agent 决定调用一个工具；携带工具名、参数和唯一调用 ID
+- `agent-loop-tool-result` — 一个工具执行完毕；携带输出摘要和计时元数据
+- `agent-loop-step-done` — 当前 LLM 流式调用已完成；一个步骤可能包含多次工具调用
+- `agent-loop-done` — 整个 Agent 循环已完成；会话返回空闲状态
+- `agent-loop-error` — 发生了错误；会话以明确的错误信息转换到错误状态
+- `agent-context-usage` — 每次迭代发出，传达当前 Token 使用量及是否需要压缩
+
+UI 中的每个状态转换都由这些事件之一驱动。没有轮询。前端是纯响应式的。
+
+## 循环执行器
+
+Agent 的核心是 DocKit 所称的*循环执行器*（loop runner）——一个在 Rust 中协调从用户消息到最终响应的完整 Agent 交互的函数。
+
+与其说它是一个函数，不如说它是一个进程：它最多运行 20 次迭代，每次迭代都涉及发起一次 LLM 调用、解析响应，然后决定下一步做什么。如果 LLM 返回纯文本回复，循环结束。如果 LLM 返回工具调用——它想对数据库执行的函数——循环暂停、执行这些工具（如需则经用户确认）、将结果反馈给 LLM，然后继续。
+
+每次迭代遵循一致的序列：
+
+1. 通过 `agent-context-usage` 发送当前 Token 使用量
+2. 如果 Token 使用量偏高，可选地执行上下文压缩
+3. 从 SQLite 加载对话历史
+4. 构建 LLM 请求（消息 + 工具定义）
+5. 流式处理 LLM 响应，随着到来发出 `agent-loop-delta` 和 `agent-loop-thinking-delta` Token
+6. 如果响应包含工具调用：持久化助手消息，处理每个工具调用（权限检查、确认、执行）
+7. 持久化工具结果并进入下一次迭代
+8. 如果响应是最终回复：持久化它并发出 `agent-loop-done`
+
+值得注意的是每一步之后的持久化。与将所有内容保存在内存中的玩具 Agent 不同，DocKit 在每个有意义的状态变化时都写入 SQLite。这意味着步骤之间的崩溃不会丢失数据，可以从历史记录加载会话，并且工具结果可用于后续检查，即使完整输出对于 UI 来说太大。
+
+## 前端 Composable
+
+在 Vue 3 端，Agent 交互由一个 Composable 编排——`useChatAgent`——它连接所有事件监听器并向 UI 暴露一个简单的 `sendMessage` 接口。
+
+Composable 模式在这里很合适，因为它将所有 Tauri IPC 复杂性与应用程序其余部分隔离开来。使用它的视图和 Store 对事件名称或 invoke 命令一无所知。它们得到一个 `sendMessage` 函数和随着事件到来而更新的响应式状态。
+
+当用户发送消息时，Composable：
+
+1. 创建或解析会话 ID
+2. 立即将用户消息插入本地 Store（无需等待服务器往返——UI 感觉即时）
+3. 从后端获取工具定义（如果会话附加了数据库连接）
+4. 构建系统提示，整合附加的数据源、Schema 和任何会话特定规则
+5. 用消息、设置和连接配置调用 Rust 后端的 `run_agent_loop`
+6. 从那时起，Composable 是纯响应式的——传入的事件更新 Store，Store 更新 UI
+
+这种分离很重要：Composable 是前端中唯一了解 Tauri 事件的地方。它之上的一切（视图、Store、其他 Composable）都使用普通的 Vue 响应式状态。
+
+### 功能适配器
+
+DocKit 有两个独立的 Agent UI：数据工作室中的全屏聊天，以及可从任何连接视图访问的侧边栏助手。它们有不同的上下文、不同的会话生命周期和不同的附加数据库连接方式。
+
+与其构建两个独立的 Agent 集成，DocKit 使用了轻量的适配器模式。`useDataStudioChatAgent` 和 `useSidebarChatAgent` 各自用功能特定的逻辑包装 `useChatAgent`：创建哪些会话、注入什么上下文、如何暴露连接。核心编排逻辑存在于基础 Composable 中，只有一份。
+
+## 会话状态的存放位置
+
+DocKit 中的会话有两种状态，按设计存放在不同的地方：
+
+**运行时状态**（不持久化）——在会话开始时获取的工具定义和元数据、从 Token 事件中组装的流式助手消息、等待用户输入的确认通道。这种状态是临时的，每次循环运行时重新构建。
+
+**持久化状态**（SQLite）——对话消息、工具调用记录、工具结果、会话元数据。这是可以从历史记录加载、导出或用作下一次 LLM 调用基础的持久记录。
+
+这种分离很重要，因为它防止了陈旧数据跨会话持久化，同时确保真正重要的内容不会丢失。
+
+## 为什么这个架构有效
+
+这个设计的任何单个部分都没有新颖的见解。IPC 桥接、事件驱动的 UI 和持久化会话存储都是标准模式。让这个架构保持一致性的是它们的组合：
+
+- Agent 的不安全面（数据库访问、网络调用、文件处理）被隔离在它应在的原生进程中
+- UI 是纯响应式的——它无法意外触发副作用；它只是响应事件
+- 持久化层在每一步都在，而不只在最后——系统对部分失败有弹性
+- Composable 抽象阻止了 Tauri 实现细节泄漏到应用程序代码中
+
+本系列的第二篇将深入工具系统的设计——具体是工具如何被定义为带有风险级别和权限的一等数据结构，以及为什么这些元数据的重要性远不止调用正确的数据库函数。
+
+---
+
+*DocKit 是开源的。这里描述的架构存在于 [`src-tauri/src/agent/`](https://github.com/geek-fun/dockit/tree/master/src-tauri/src/agent)（Rust）和 [`src/composables/`](https://github.com/geek-fun/dockit/tree/master/src/composables)（Vue 3）中。如果你在构建类似的东西，代码是最好的文档。*

--- a/docs/zh/blog/building-ai-agent-memory.md
+++ b/docs/zh/blog/building-ai-agent-memory.md
@@ -1,0 +1,163 @@
+---
+title: "生产级 AI Agent 工程实践：内存与上下文压缩（第四篇）"
+description: DocKit 如何通过两级压缩策略、精确的 Token 计数和模型注册表，让 AI Agent 在长对话中保持功能正常——不因上下文窗口耗尽而崩溃。
+head:
+  - - meta
+    - name: keywords
+      content: AI Agent 上下文管理, LLM 上下文窗口, Agent 内存压缩, Token 计数, tiktoken, 上下文摘要, LLM Agent 内存, 上下文压缩策略
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-memory
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-memory
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "生产级 AI Agent 工程实践：内存与上下文压缩（第四篇）",
+        "description": "DocKit 如何通过两级压缩策略、精确 Token 计数和模型注册表，让 AI Agent 在长对话中保持功能正常。",
+        "image": "https://www.geekfun.club/og/master-zh.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "inLanguage": "zh-CN",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/zh/blog/building-ai-agent-memory" },
+        "keywords": ["AI Agent 内存", "上下文压缩", "Token 计数", "LLM 上下文窗口", "tiktoken"],
+        "articleSection": "AI Agent 工程"
+      }
+---
+
+# 生产级 AI Agent 工程实践：内存与上下文压缩（第四篇）
+
+*第四篇，共五篇 — [第一篇：架构设计](/zh/blog/building-ai-agent-architecture) · [第二篇：工具系统设计](/zh/blog/building-ai-agent-tools) · [第三篇：权限与确认](/zh/blog/building-ai-agent-permissions) · [第五篇：持久化与容错](/zh/blog/building-ai-agent-persistence)*
+
+---
+
+有一种特定的 Agent 失败模式，只有在你把东西交给真实用户之后才会出现：对话变长，然后某个时刻 Agent 停止工作。
+
+不是因为崩溃。不是因为 Bug。而是因为你把它构建成了一个把所有消息都填入上下文窗口的东西，现在窗口满了。API 返回一个错误，Agent 不知道怎么办。会话对用户来说已经死了。
+
+这是你在写教程的时候看不到的那类失败，因为教程会话很短。生产用户会保持对话运行更长时间，他们会调用工具返回大型数据集，他们会问后续问题，他们会期望 Agent 记住五分钟前讨论的内容。
+
+DocKit 用分级上下文管理系统解决了这个问题。这篇文章解释它的工作原理。
+
+## 了解你的上下文预算
+
+在任何压缩逻辑之前，系统需要知道它有多少上下文可以使用，以及它使用了多少。
+
+DocKit 维护一个**模型注册表**——每个支持的 LLM 提供商和模型的规格记录。注册表中的每条记录包含：
+
+- 模型名称（以及同一模型的别名，因为 API 提供商对相同模型使用不同的标识符）
+- 上下文窗口大小（以 Token 为单位）
+- 最大输出 Token 数
+- 提供商标识符（openai、anthropic、deepseek、generic）
+- 模型类别（推理型 vs. 对话型，影响某些行为）
+
+在操作开始之前，循环执行器通过模型名称在注册表中查找，以确定可用的总上下文预算。这个预算在整个会话中被保留——它不在每次迭代时重新查询。
+
+### 按提供商计数 Token
+
+了解你的预算是不够的；你还需要知道你在使用多少。Token 计数由于 LLM 提供商对其分词器使用不同方法而变得复杂。
+
+DocKit 的 Token 计数层根据提供商进行分支：
+
+**对于 OpenAI**，DocKit 使用 tiktoken-rs，OpenAI 自己的分词库的 Rust 移植。这给出了精确的 BPE Token 计数，与 OpenAI 在 API 层面计算的完全一致。你不会因为大型对话的估算误差而意外超出预算。
+
+**对于 Anthropic**，没有公开的分词库，所以 DocKit 使用基于字符的启发式方法：每三到四个字符大约对应一个 Token（具体比率 3.5 字符/Token）。对于中等长度的对话，这种估算通常在真实 Token 数的 5-10% 以内。
+
+**对于 DeepSeek**，由于其分词器与标准 BPE 的差异，比率略有调整（3.2 字符/Token）。
+
+**对于其他提供商**，使用中间比率（3.3 字符/Token）作为合理的默认值。
+
+计数发生在每个 Agent 循环迭代中，在系统消息、所有对话消息（用户消息、助手消息、工具调用和工具结果）以及将发送给 LLM 的工具定义上。结果通过 `agent-context-usage` 事件发送到前端，UI 将其显示为上下文占用指示器。
+
+### 压缩触发器
+
+每次迭代，系统计算一个利用率百分比：当前 Token 使用量除以上下文窗口大小。当这个百分比超过 60%，压缩就会开始。
+
+60% 的阈值不是任意的。在 OpenAI 的 gpt-4o（128k Token 窗口）上，60% 利用率意味着大约 76,000 个 Token 已被使用，还剩约 51,000 个空余。这足以容纳当前对话的其余部分，加上工具调用结果，以及一些工作空间，而不会有立即耗尽预算的风险。
+
+更早触发（比如 40%）会增加压缩频率并浪费推理能力。更晚触发（比如 80%）会减少边际情况的余量。60% 在常见的会话模式中平衡得比较好。
+
+## 两级压缩
+
+当触发压缩时，系统选择两个策略中的一个，具体取决于情况的紧迫程度。
+
+### T1：微压缩
+
+T1 是第一道防线，保守且快速。它不移除任何消息，不调用 LLM，不更改对话历史。它只做一件事：**省略工具结果体**。
+
+对于对话历史中的每条 `tool_result` 消息，如果其内容体超过 800 个字符，T1 用占位符替换该体，并注明完整结果存储在历史记录中，如有需要可检索。工具调用记录本身——工具名称、参数、时间戳——保持完整。
+
+效果通常是显著的。Elasticsearch 搜索查询可以返回数十个包含完整文档内容的命中结果。DynamoDB 查询可以返回大型 JSON 对象。这些结果在工具调用时对 LLM 很有用，但一旦对话继续，它们通常不再需要全保留在上下文中——LLM 已经处理过它们了。
+
+T1 压缩在 Rust 中操作内存中的消息，完成速度是亚毫秒级的，用户几乎不会察觉延迟。
+
+### T2：LLM 摘要压缩
+
+当 T1 不够用时——要么是因为即使在省略工具结果体之后利用率仍然很高，要么是因为距离上次压缩只过了几次迭代——系统升级到 T2。
+
+T2 向 LLM 本身发出第二次调用，用一组特定的指令：将对话历史总结为一个结构化的九节摘要。这些节包括：
+
+1. **会话目标** — 用户最初想要实现什么
+2. **已建立的上下文** — 数据库、索引和已确认的事实
+3. **操作摘要** — 执行了哪些工具及其结果
+4. **当前状态** — 事情目前处于什么状态
+5. **待解决问题** — 仍然开放的问题或任务
+6. **重要数据** — 对后续对话至关重要的特定值（索引名称、ID、配置）
+7. **决策和发现** — 过程中做出的任何关键选择
+8. **错误和警告** — 发生了什么故障
+9. **下一步** — 对话应该继续的方向
+
+摘要替换了完整的对话历史，在持久化层中将旧消息标记为已压缩。保留最后四对消息（用户 + 助手交换）以保持即时上下文，并附加摘要。这样既能保持刚刚发生的对话的连贯性，又能大幅减少 Token 预算中旧历史占用的空间。
+
+T2 有成本——一次额外的 LLM 调用意味着延迟和 Token 消耗。只要有 T1 就够了，这个成本是值得的。T2 保留给 T1 不足以恢复足够预算空间的情况。
+
+### 故障保险：三次失败断路器
+
+如果两级压缩都不能让 Token 利用率降到 60% 以下，会发生什么？
+
+DocKit 用断路器处理这个问题：连续三次压缩尝试都失败后，系统停止自动尝试压缩，并发出一个明确的 `agent-loop-error` 事件，说明上下文已满、会话需要重置。
+
+这比无限重试要好，因为每次压缩失败都会本身消耗 Token，让情况变得更糟。断路器可以防止一旦处于无法恢复的状态就在一个失败循环中消耗资源。
+
+## 前端上下文指示器
+
+`agent-context-usage` 事件使所有这些对用户可见。UI 在每次迭代后更新，显示：
+
+- Token 使用量（已使用 / 总计）
+- 可视化进度条（在 60% 以上变黄，在 80% 以上变红）
+- 一个指示器，说明是否刚刚发生了压缩
+
+这种可见性对用户信任很重要。当 Agent 行为改变时——比如因为压缩了旧上下文——用户可以看到为什么，而不必去猜测 Agent "忘记"了一些早先讨论的内容。
+
+## 为什么这设计按正确的抽象层工作
+
+从 T1 到 T2 的分级方法反映了一个关键的设计原则：**先用廉价的启发式方法，仅在必要时才升级到昂贵的操作。**
+
+省略工具结果体——T1——是纯文本操作，零推理成本。它解决了最常见的上下文膨胀来源（大型工具输出）而不触及更昂贵的 LLM 调用。
+
+LLM 摘要——T2——是正确的工具，但使用起来有成本。预留给真正需要语义理解来压缩内容的情况：什么时候消息本身（而不仅仅是工具结果）占据了太多空间。
+
+断路器防止了这两者都会失败的情况变成无限的资源消耗。
+
+模型注册表和 Token 计数层做了对于这一切正常工作至关重要的基础工作：确保系统知道它有多少预算，并且知道它已经消耗了多少，精确到能够在临界问题发生之前触发压缩。
+
+本系列的第五篇（也是最后一篇）涵盖持久化和容错——SQLite 会话存储、每步写入模型、跨提供商错误恢复，以及指数退避重试策略的细节，这些策略使 Agent 循环在瞬态 API 失败下也能保持可靠。
+
+---
+
+*Token 计数在 [`src-tauri/src/agent/token_counter.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/token_counter.rs) 中。压缩逻辑在 [`src-tauri/src/agent/compact.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/compact.rs) 中。模型注册表在 [`src-tauri/src/agent/model_registry.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/model_registry.rs) 中。*

--- a/docs/zh/blog/building-ai-agent-permissions.md
+++ b/docs/zh/blog/building-ai-agent-permissions.md
@@ -1,0 +1,144 @@
+---
+title: "生产级 AI Agent 工程实践：权限与确认（第三篇）"
+description: DocKit 如何为 AI Agent 实现多层权限模型——会话级模式、每连接权限、基于风险的确认，以及减少摩擦而不牺牲安全的持久允许/拒绝规则。
+head:
+  - - meta
+    - name: keywords
+      content: AI Agent 权限, Agent 确认流程, 人机协同 AI, AI Agent 安全, LLM 工具确认, Agent 权限模型, AI Agent 用户体验, oneshot 通道确认
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-permissions
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-permissions
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "生产级 AI Agent 工程实践：权限与确认（第三篇）",
+        "description": "DocKit 如何为 AI Agent 实现多层权限模型——会话级模式、每连接权限、基于风险的确认，以及减少摩擦而不牺牲安全的持久允许/拒绝规则。",
+        "image": "https://www.geekfun.club/og/master-zh.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "inLanguage": "zh-CN",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/zh/blog/building-ai-agent-permissions" },
+        "keywords": ["AI Agent 权限", "人机协同", "确认流程", "Agent 安全", "权限模型"],
+        "articleSection": "AI Agent 工程"
+      }
+---
+
+# 生产级 AI Agent 工程实践：权限与确认（第三篇）
+
+*第三篇，共五篇 — [第一篇：架构设计](/zh/blog/building-ai-agent-architecture) · [第二篇：工具系统设计](/zh/blog/building-ai-agent-tools) · [第四篇：内存与上下文压缩](/zh/blog/building-ai-agent-memory) · [第五篇：持久化与容错](/zh/blog/building-ai-agent-persistence)*
+
+---
+
+在操作真实系统的 Agent 中，最难的 UX 问题不是 AI 部分，而是信任部分。
+
+如果每一个动作都需要手动批准，Agent 就毫无用处——你是在通过一个更差的界面亲自完成工作。如果每一个动作都是自动的，你就把一个 LLM 的访问权限交给了你的生产数据库。这两种极端对真实用户和真实系统都不适用。
+
+DocKit 的权限模型是寻找这种平衡的尝试。它使用四个独立的策略层，在运行时组合起来决定特定工具调用是应该自动进行还是等待人工确认。这篇文章解释这些层如何工作以及为什么这样设计。
+
+## 会话对其连接了解什么
+
+当用户将数据库连接附加到 Agent 会话时，DocKit 获取一个快照——而不是实时引用。快照在附加时冻结了连接的别名、类型和权限。如果连接配置之后发生变化（密码轮换、权限更新），正在运行的会话不受影响，直到使用新配置明确重启。
+
+这是一个刻意的安全选择。实时引用意味着会话的能力可能在对话进行中从其下方改变，这很难推理，而且可能有危险。冻结的快照意味着会话在整个生命周期内都在已知的、稳定的能力集内运行。
+
+每个连接快照携带一个权限映射：`read`、`create`、`update` 和 `delete` 的布尔标志集合。这些标志定义了在该连接上哪些操作是可行的——不只是 Agent 被允许请求什么，而是实际上会执行什么。
+
+## 四个策略层
+
+### 第一层：会话允许列表
+
+允许列表是最外层的环。当会话启动时，可以配置 Agent 被允许调用的特定工具名称集。不在列表上的任何工具在权限或确认逻辑甚至运行之前就被拒绝。
+
+这一层是粗粒度且绝对的。它适合创建有意受限的会话——一个"只读分析"会话，即使连接技术上有写权限，也无法访问任何写工具。
+
+### 第二层：每连接权限检查
+
+对于通过允许列表的任何工具，系统查找该工具的 `required_permission`（来自第二篇描述的工具注册表），并检查附加的连接是否授予了该权限。
+
+这个检查在 Rust 中运行，在循环执行器内部，在任何数据库调用之前。前端没有绕过它的机制。这很重要，因为它意味着权限强制不是可以被绕过的前端策略——它是后端不变量。
+
+实际用途：将只读副本连接到会话并只授予 `read` 权限。任何需要 `create`、`update` 或 `delete` 的工具都将失败这个检查，无论其他一切如何——即使用户的自动模式已开启，即使该工具有"始终允许"规则。连接权限是一个硬性底线。
+
+### 第三层：会话级权限模式
+
+在每连接权限之上，会话有一个模式：`Ask`（询问）或 `Auto`（自动）。
+
+在 `Ask` 模式（默认）下，即使连接授予了所需权限，高风险工具也需要明确的用户确认。在 `Auto` 模式下，高风险工具无需确认即可进行——只有破坏性风险的工具仍然需要确认。
+
+这个模式可以在会话级别设置（应用于所有连接），也可以按连接设置。会话可能对只读副本使用 `Auto` 模式（最坏情况是一个慢查询），但对发生写操作的主连接保持 `Ask` 模式。
+
+模式切换是一个刻意的摩擦控制。知道自己在做什么并已验证其连接的用户可以减少中断。想要保持在循环中的用户可以要求对任何超出读取的内容进行确认。
+
+### 第四层：持久确认规则
+
+最细粒度的层是确认规则——持久的、会话范围的记录，表示"对于这个会话，始终允许工具 X"或"对于这个会话，始终拒绝工具 Y"。
+
+规则在会话重启后依然存在（它们持久化在前端 Store 中）。一旦用户决定在某个特定会话中对 `es__search` "始终允许"，他们在该会话中就不会再被询问了。拒绝同理："始终拒绝" `es__delete_by_query` 意味着无论模式或权限如何，该工具都被封锁。
+
+规则在风险级别和模式逻辑之前被检查。匹配的规则使整个确认决策短路：始终允许意味着工具立即进行，始终拒绝意味着它立即失败，不显示任何 UI 提示。
+
+## 确认握手
+
+当工具调用确实需要确认时，这个决策如何从 UI 回到正在运行的后端，其机制值得理解。
+
+在 Rust 中异步运行的循环执行器为工具调用创建一个 oneshot 通道。发送端放入一个全局 `ConfirmMap`，以工具调用 ID 为键。循环执行器然后等待接收端——它是挂起的，不是在轮询，等待时不消耗 CPU。
+
+在 UI 中，用户看到工具调用及其参数和风险级别，做出决策。前端调用带有工具调用 ID 和决策（批准或拒绝）的 Tauri 命令。在 Rust 端，该命令在 `ConfirmMap` 中查找发送端，发送布尔值，并移除条目。
+
+循环执行器的等待解析。如果批准，它继续执行工具。如果拒绝，它将失败消息插入对话并继续循环——LLM 了解到工具被拒绝，可以调整其计划。
+
+几个值得注意的实现细节：
+
+**条目在 drop 时被清理。** `ConfirmGuard` 包装 ConfirmMap 条目，并在被 drop 时移除它，无论循环执行器如何退出。这防止了在会话出错或在确认过程中被取消时 map 中积累陈旧条目。
+
+**超时时间为五分钟。** 如果没有决策到来，确认超时，会话以清晰的错误消息失败。这防止了如果用户关闭窗口或忘记待定确认时会话无限期挂起。
+
+**对自动允许工具立即确认。** 当工具不需要确认时（安全风险级别、自动模式或始终允许规则），前端立即调用带有 `approved = true` 的确认命令，不等待用户输入。从后端角度来看，所有工具调用都是一样的——它们等待确认信号。关于是否显示 UI 提示的决策完全在前端进行，后端不需要知道。
+
+## 确认决策树
+
+当 `onAgentLoopToolCall` 在前端到达时，Composable 按这个优先顺序处理：
+
+1. 是否有会话规则说对这个工具**始终拒绝**？→ 立即拒绝，不显示 UI 提示
+2. 是否有会话规则说对这个工具**始终允许**？→ 立即批准，不显示 UI 提示
+3. 风险级别是否为 **Safe**？→ 立即批准，不显示 UI 提示
+4. 风险级别是否为 **Destructive**？→ 始终显示确认，无论模式如何
+5. 会话是否处于 **Auto** 模式？→ 立即批准，不显示 UI 提示
+6. 否则（Elevated 风险，Ask 模式）→ 显示确认提示
+
+这种有序评估意味着最具体的信号获胜。会话规则始终胜过模式设置，模式设置始终胜过默认风险行为。用户可以随着时间对特定工具建立信心（添加始终允许规则），而不会为新的、不熟悉的工具禁用安全检查。
+
+## 为什么这个设计随时间保持良好
+
+分层模型分离了随系统增长否则会变得纠缠的关注点：
+
+添加新工具不需要更新权限逻辑——工具声明自己的风险级别和所需权限，现有规则自动适用。
+
+支持新数据库类型不需要新的确认代码——权限检查针对通用权限键（`create`、`update` 等），而不是数据库特定概念。
+
+想要更严格控制的用户可以收紧各个层（限制允许列表、保持 Ask 模式、添加拒绝规则），而不影响想要更宽松操作的用户。系统根据你需要的谨慎程度而谨慎，根据你可以信任的流畅程度而流畅。
+
+这个模型目前没有很好解决的一件事是跨会话规则共享。规则限于会话，这是隔离的正确默认设置。但跨许多会话工作的有经验用户可能想要全局的"始终允许只读工具"规则。这是这个设计的自然演进方向。
+
+第四篇转向了不同的方向——远离安全，转向破坏最多生产 Agent 的工程问题：上下文窗口。一旦你的 Agent 运行长对话，Token 预算就会填满，没有压缩策略，Agent 就会停止工作。DocKit 的解决方案涉及两层压缩、自定义 Token 计数层，以及了解每个主要 LLM 提供商上下文限制的模型注册表。
+
+---
+
+*确认逻辑在 [`src/composables/useChatAgent.ts`](https://github.com/geek-fun/dockit/blob/master/src/composables/useChatAgent.ts) 中。后端确认通道在 [`src-tauri/src/agent/loop_runner.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/loop_runner.rs) 中。*

--- a/docs/zh/blog/building-ai-agent-persistence.md
+++ b/docs/zh/blog/building-ai-agent-persistence.md
@@ -1,0 +1,176 @@
+---
+title: "生产级 AI Agent 工程实践：持久化与容错（第五篇）"
+description: DocKit 如何通过每步 SQLite 写入、指数退避重试策略和跨提供商错误恢复，让 AI Agent 对 API 失败和意外崩溃保持弹性。
+head:
+  - - meta
+    - name: keywords
+      content: AI Agent 持久化, Agent 容错, LLM 重试策略, Agent 会话恢复, SQLite Agent 存储, 指数退避, Agent 错误处理, LLM API 弹性
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-persistence
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-persistence
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "生产级 AI Agent 工程实践：持久化与容错（第五篇）",
+        "description": "DocKit 如何通过每步 SQLite 写入、指数退避重试和跨提供商错误恢复，让 AI Agent 对 API 失败和意外崩溃保持弹性。",
+        "image": "https://www.geekfun.club/og/master-zh.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "inLanguage": "zh-CN",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/zh/blog/building-ai-agent-persistence" },
+        "keywords": ["AI Agent 持久化", "容错", "重试策略", "会话恢复", "SQLite", "指数退避"],
+        "articleSection": "AI Agent 工程"
+      }
+---
+
+# 生产级 AI Agent 工程实践：持久化与容错（第五篇）
+
+*第五篇，共五篇 — [第一篇：架构设计](/zh/blog/building-ai-agent-architecture) · [第二篇：工具系统设计](/zh/blog/building-ai-agent-tools) · [第三篇：权限与确认](/zh/blog/building-ai-agent-permissions) · [第四篇：内存与上下文压缩](/zh/blog/building-ai-agent-memory)*
+
+---
+
+生产 Agent 遇到的失败类型与开发时遇到的不同。
+
+在开发中，你的 LLM 调用成功，工具执行，用户看到结果。在生产环境中，API 在凌晨三点开始返回 503 错误，用户在工具执行中途关闭笔记本电脑，Anthropic 出现服务中断，用户的请求在 LLM 流式传输中途超时。
+
+如果你的 Agent 将所有内容保存在内存中并在任何失败时完全崩溃，这些场景都会成为数据丢失和糟糕的用户体验。DocKit 用两个系统解决了这个问题：**每步持久化**和**多层错误恢复**。
+
+## 每步 SQLite 写入
+
+DocKit 的持久化策略不是在会话结束时保存——而是在每个有意义的状态变化时保存。
+
+循环执行器在以下每一步之后写入：
+
+1. 用户消息到达（立即持久化，在任何 LLM 调用之前）
+2. LLM 流式响应完成（持久化完整的助手消息）
+3. 工具调用决定（持久化工具调用记录和参数）
+4. 工具执行完成（持久化工具结果和元数据）
+5. 会话状态变化（空闲 → 运行中 → 错误）
+6. 压缩事件（标记旧消息为已压缩，写入摘要）
+
+这种细粒度的写入模式意味着步骤之间的崩溃不会丢失任何内容。用户消息始终被保存，即使 LLM 调用永远没有发生。工具结果始终被保存，即使助手的后续回复没有发生。一个会话可以在任何步骤中断，重新加载时，它从精确中断的地方恢复。
+
+### 会话模式
+
+会话在 SQLite 中以规范化的模式存储：
+
+- `agent_sessions` — 会话元数据：ID、创建时间、状态、附加的连接引用、配置快照（第三篇描述的权限模式、确认规则）
+- `agent_messages` — 对话历史：角色（user/assistant/tool_result/tool_call）、内容、时间戳、序号、压缩标志
+- `agent_tool_calls` — 工具执行记录：工具名称、序列化参数、执行时间、结果摘要、成功/失败标志
+
+规范化很重要，因为它使增量更新成为可能而不是完整重写。当工具调用完成时，系统只需更新 `agent_tool_calls` 中的那一行，而不是重新序列化整个会话。在高频写入路径上，这避免了大量不必要的工作。
+
+### 从历史记录重建上下文
+
+当用户从历史记录加载会话时，循环执行器不是从空状态开始，而是：
+
+1. 从 SQLite 获取所有未压缩的消息
+2. 如果存在，获取最新的压缩摘要
+3. 构建 LLM 上下文：摘要（如果存在）+ 保留的消息
+4. 将会话状态设置为 `idle`（而不是 `running`，因为没有活跃的 LLM 调用待处理）
+
+这意味着历史记录中的会话不仅仅是查看用途的记录——它们可以继续，带有完整的上下文（或尽可能多的上下文）。
+
+## 错误分类
+
+生产中的 LLM API 失败并非都一样。某些失败是瞬态的并且值得重试；某些是永久性的需要立即失败；某些需要指数退避；某些需要特殊处理。
+
+DocKit 的错误处理层按这些类别分类错误：
+
+### 可重试错误（带退避）
+
+这些是瞬态基础设施问题，往往会自行解决：
+
+- **速率限制**（HTTP 429，错误代码 `rate_limit_exceeded`）— LLM 提供商在短时间内的请求过多时触发，通常在几秒到几分钟后解除
+- **配额不足**（`insufficient_quota`）— 通常是暂时的，特别是在共享 API 密钥或包月计划上；有时值得重试，因为配额可能每分钟重置
+- **服务不可用**（HTTP 503，`service_unavailable`）— 提供商端的瞬态故障
+- **提供商过载**（`overloaded_error`）— Anthropic 特定的错误，在高负载时返回
+
+### 不可重试错误（立即失败）
+
+这些表明需要用户干预的根本问题：
+
+- **认证失败**（HTTP 401，`invalid_api_key`）— API 密钥无效或已过期；重试不会修复它
+- **权限不足**（HTTP 403）— 账户没有使用该模型的权限
+- **模型不存在**（HTTP 404，`model_not_found`）— 请求的模型不可用；可能是配置错误或已弃用的模型
+- **无效请求**（HTTP 400，`invalid_request_error`）— 发送的内容有问题（无效参数、内容被拒绝等）
+- **上下文长度超出**（`context_length_exceeded`）— 消息超过了模型的最大上下文；压缩应该已经阻止了这种情况，但如果发生，立即失败并显示有用的错误信息
+
+### 重试策略
+
+对于可重试错误，DocKit 使用带抖动的指数退避：
+
+- 首次重试：等待 1 秒 ± 250ms
+- 第二次重试：等待 3 秒 ± 250ms
+- 第三次重试：等待 8 秒 ± 250ms
+- 三次失败后：放弃并以明确的错误消息失败
+
+抖动（±250ms 随机偏移）防止了"惊群效应"——如果多个 Agent 会话同时遇到速率限制并在完全相同的时刻重试，它们可能会触发另一个速率限制。随机偏移使重试交错开来。
+
+1/3/8 秒的梯度比均匀间隔更有效，因为大多数瞬态故障在第一次重试时就解决了，而真正的服务中断通常需要更长时间。在 1 秒后第一次重试是快速的——用户几乎不会注意到延迟。如果第一次重试失败了，3 秒和 8 秒的间隔给服务更多时间恢复，而不会永远等待。
+
+### 跨提供商错误规范化
+
+OpenAI、Anthropic 和 DeepSeek 以不同格式报告错误。OpenAI 在 JSON 响应体中返回结构化错误对象。Anthropic 使用其自己的错误类型系统。某些提供商在某些失败类型上只返回 HTTP 状态码，没有结构化的错误体。
+
+DocKit 的提供商层（`harness.rs`）在错误到达重试逻辑之前对其进行规范化。规范化器将提供商特定的错误表示映射到一致的内部类型：可重试或不可重试，带有人类可读的消息，适合向用户展示。
+
+这意味着重试逻辑不需要了解提供商差异——它对所有提供商的运作方式相同。
+
+## 流式恢复
+
+LLM 调用失败最烦人的地方之一是 LLM 在流式传输 80% 的响应后失败。用户已经看到了部分响应流入——然后一切停止，会话崩溃。
+
+DocKit 通过在流结束之前不持久化助手消息来处理这个问题。在流式调用期间，Token 通过 `agent-loop-delta` 事件发送到 UI，但完整消息在后端仍然是流式缓冲区中的内存内容。
+
+只有当流干净地完成（所有 Token 都已到达，LLM 发送了停止信号）时，消息才被写入 SQLite。
+
+如果流中途失败——超时、网络断开、提供商错误——缓冲区被丢弃，不写入任何内容。循环执行器触发重试，重新启动整个 LLM 调用，从最后一个持久化消息开始。UI 清除部分流式输出并重新开始。
+
+用户体验是：响应开始出现，然后重置并从头开始。这比显示截断的、损坏的响应或留下半完成的状态更好。
+
+## 状态机与错误可见性
+
+循环执行器维护一个明确的状态机，用于会话：`Idle`、`Running`、`Error`。这些状态通过 `agent-loop-error` 和 `agent-loop-done` 事件传播到前端。
+
+明确的错误状态意味着 UI 永远不必猜测 Agent 是否正在工作、是否完成或是否出了问题。会话要么正在运行（流式指示器可见），要么空闲（等待输入），要么处于错误状态（显示带有重试选项的错误消息）。
+
+错误消息是故意具体的。不是"发生了一些错误"，而是"速率限制超过了，将在 8 秒后重试"或"API 密钥无效——请检查你的设置"或"上下文窗口已满——开始新会话继续"。用户了解发生了什么，以及下一步需要做什么。
+
+## 综合来看
+
+这五篇文章描述的系统代表了一种生产 AI Agent 的特定方法：
+
+- **Rust 后端承载危险代码**——数据库访问、网络调用、并发状态管理——而前端保持纯响应式
+- **工具被定义为携带安全元数据的数据**，而不只是可调用的函数
+- **权限是防御层**，在执行层强制执行，而不是仅在 UI 层
+- **上下文管理是主动的**，带有廉价启发式和昂贵 LLM 压缩的分级方法
+- **持久化在每一步发生**，使系统对部分失败有弹性
+- **错误分类驱动恢复**，带有适当的重试策略和有意义的用户消息
+
+这些决策都不是尖端的 AI 研究。它们是使系统在真实条件下对真实用户工作所需的工程工作。
+
+如果你正在构建生产 Agent，这里最重要的一课是：**从技术上让 Agent 工作的工作量与让它在生产中可靠工作的工作量相比微不足道。** 上下文管理、错误恢复、持久化、权限——这些后来的系统往往占开发时间的大部分，却在演示视频中几乎看不到。
+
+DocKit 是开源的。如果你在构建类似的东西，这个代码库是你比教程或论文获益更多的参考。
+
+---
+
+*持久化在 [`src-tauri/src/agent/loop_runner.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/loop_runner.rs) 中。提供商规范化在 [`src-tauri/src/agent/harness.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/harness.rs) 中。*

--- a/docs/zh/blog/building-ai-agent-tools.md
+++ b/docs/zh/blog/building-ai-agent-tools.md
@@ -1,0 +1,181 @@
+---
+title: "生产级 AI Agent 工程实践：工具系统设计（第二篇）"
+description: DocKit 如何将工具定义为带有风险级别和所需权限的一等数据结构，ToolExecutor trait 为何对可测试性至关重要，以及每次工具调用在执行前需经过的三道关卡。
+head:
+  - - meta
+    - name: keywords
+      content: AI Agent 工具, LLM 函数调用, 工具系统设计, Agent 工具权限, 风险级别分类, ToolExecutor 模式, Agent 安全, Rust LLM 工具
+  - - link
+    - rel: canonical
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: en
+      href: https://www.geekfun.club/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: zh
+      href: https://www.geekfun.club/zh/blog/building-ai-agent-tools
+  - - link
+    - rel: alternate
+      hreflang: x-default
+      href: https://www.geekfun.club/blog/building-ai-agent-tools
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "生产级 AI Agent 工程实践：工具系统设计（第二篇）",
+        "description": "DocKit 如何将工具定义为带有风险级别和所需权限的一等数据结构，ToolExecutor trait 的设计意图，以及工具调用的三道安全关卡。",
+        "image": "https://www.geekfun.club/og/master-zh.png",
+        "author": { "@type": "Organization", "name": "GEEKFUN", "url": "https://www.geekfun.club" },
+        "publisher": { "@type": "Organization", "name": "GEEKFUN", "logo": { "@type": "ImageObject", "url": "https://www.geekfun.club/geekfun.png" } },
+        "datePublished": "2026-05-22",
+        "dateModified": "2026-05-22",
+        "inLanguage": "zh-CN",
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.geekfun.club/zh/blog/building-ai-agent-tools" },
+        "keywords": ["AI Agent 工具", "函数调用", "工具权限", "风险级别", "ToolExecutor", "Agent 安全"],
+        "articleSection": "AI Agent 工程"
+      }
+---
+
+# 生产级 AI Agent 工程实践：工具系统设计（第二篇）
+
+*第二篇，共五篇 — [第一篇：架构设计](/zh/blog/building-ai-agent-architecture) · [第三篇：权限与确认](/zh/blog/building-ai-agent-permissions) · [第四篇：内存与上下文压缩](/zh/blog/building-ai-agent-memory) · [第五篇：持久化与容错](/zh/blog/building-ai-agent-persistence)*
+
+---
+
+谈到 AI Agent 的"工具调用"，讨论通常停在 API 层面：你把 JSON Schema 传给 LLM，它返回一个函数名和参数，你调用那个函数。这部分很简单。难的地方——对生产环境真正重要的地方——在于调用前后发生了什么。
+
+调用之前：这个 Agent 是否有权限调用这个工具？这是应该自动发生的操作，还是需要人来确认？
+
+调用之后：输出是否被截断了？LLM 实际看到的是什么，存储的又是什么？如果失败，用户看到什么？
+
+DocKit 的工具系统用一套一致的设计回答了所有这些问题。这篇文章就是关于这套设计的。
+
+## 工具是数据，不只是函数
+
+第一个值得理解的设计决策：在 DocKit 中，工具不只是一个可调用的函数。它是一个系统中各处都会推理的记录：
+
+- **名称** — LLM 使用的函数标识符（例如 `es__search`、`dynamo__delete_many`）
+- **参数** — 描述预期参数的 JSON Schema，用于生成 LLM 提示和验证传入调用
+- **风险级别** — `Safe`（安全）、`Elevated`（较高）或 `Destructive`（破坏性）之一，反映操作的潜在影响
+- **所需权限** — 一个字符串键（`read`、`create`、`update`、`delete`），工具执行前必须在连接的权限配置中存在
+
+这些元数据存在于中央工具注册表中，并在 Agent 循环启动时序列化为 OpenAI 兼容的函数规范。UI 也获取这些元数据——它使用 `riskLevel` 决定是否显示确认提示，并可视化地展示让用户理解 Agent 即将执行什么。
+
+### 工具目录
+
+DocKit 内置 18 个工具，覆盖 Elasticsearch、DynamoDB 和 MongoDB：
+
+| 工具 | 风险 | 权限 |
+|------|------|------|
+| `es__search` | Safe | read |
+| `es__get_document` | Safe | read |
+| `es__cat_indices` | Safe | read |
+| `es__get_mapping` | Safe | read |
+| `es__index_document` | Elevated | create |
+| `es__update_document` | Elevated | update |
+| `es__delete_document` | Destructive | delete |
+| `es__delete_by_query` | Destructive | delete |
+| `dynamo__execute_query` | Safe | read |
+| `dynamo__describe_table` | Safe | read |
+| `dynamo__execute_write` | Elevated | create |
+| `dynamo__execute_delete` | Destructive | delete |
+| `mongo__find` | Safe | read |
+| `mongo__list_collections` | Safe | read |
+| `mongo__aggregate` | Elevated | read |
+| `mongo__insert_one` | Elevated | create |
+| `mongo__update_many` | Elevated | update |
+| `mongo__delete_many` | Destructive | delete |
+
+命名约定是刻意的：`<引擎>__<操作>`。这种基于前缀的命名使得在运行时将工具调用路由到正确的执行器变得轻而易举，并且让会话的能力对操作人员一目了然。
+
+## 执行前的三道关卡
+
+LLM 请求的每次工具调用在任何代码对数据库运行之前必须通过三个顺序检查。
+
+### 关卡一：会话允许列表
+
+允许列表是最外层的环。当会话启动时，可以配置 Agent 被允许调用的特定工具名称集。不在列表上的任何工具会在权限或确认逻辑运行之前就被立即拒绝。
+
+这一层是粗粒度且绝对的。它适合创建有意受限的会话——一个"只读分析"会话，可以访问所有读工具但不能访问任何写工具，无论连接技术上有什么权限。
+
+### 关卡二：每连接权限检查
+
+对于通过允许列表的任何工具，系统查找该工具的 `required_permission`（来自第二篇描述的工具注册表），并检查附加的连接是否授予了该权限。
+
+这个检查在 Rust 中运行，在循环执行器内部，在任何数据库调用之前。前端没有绕过它的机制。
+
+实际效果很重要：将只读副本连接附加到会话并只授予 `read` 权限，就可以保证不会有任何写操作到达它——无论 LLM 请求什么，无论用户在 UI 中配置了什么。连接权限是一个硬性底线，在执行层而非策略层强制执行。
+
+### 关卡三：用户确认
+
+第三道关卡是人工的。对于超过某个风险阈值的工具，循环执行器创建一个确认通道——用 Rust 术语叫做 oneshot 通道——并在继续之前等待用户决策。
+
+LLM 知道工具调用待定。UI 显示该调用及其参数，并询问用户是批准还是拒绝。当用户决定后，前端调用一个 Tauri 命令来解析通道，循环执行器继续。
+
+确认超时时间为五分钟。如果没有决策到来，工具调用以超时错误失败。这防止了在用户走开或忘记待定确认时会话无限期挂起。
+
+## ToolExecutor 抽象
+
+循环执行器不直接调用数据库函数。它委托给 `ToolExecutor` trait——一个接受工具名称和解析参数并返回 `ToolEnvelope` 的抽象。
+
+这种间接性值得理解，因为它不只是关于整洁的代码：
+
+**在没有真实数据库的情况下，Agent 逻辑是可测试的。** 你可以换入一个返回预设结果的 mock 执行器，并测试完整的循环执行器——流式解析、确认流程、重试逻辑——而无需任何网络调用。
+
+**执行面是有界的。** trait 定义了执行器能做什么。Agent 循环无法意外调用执行器契约之外的任何东西。
+
+**添加新数据库支持不会触及编排代码。** 添加 MongoDB 工具支持意味着向执行器添加实现，而不是修改确认如何工作或事件如何发出。
+
+具体的执行器（`DocKitToolExecutor`）通过名称前缀将工具调用路由到每个引擎的执行函数。每个引擎都有自己的认证、连接建立、验证和结果格式化。
+
+## 执行前的输入验证
+
+每个工具都有自己的验证逻辑，在任何数据库调用之前运行：
+
+对于 Elasticsearch，索引名称针对严格的字符白名单进行验证——没有路径遍历字符，没有超过 255 字节的名称，没有可能被解释为配置或元数据索引的名称。验证是显式的，拒绝模糊输入而不是尝试清理它们。
+
+对于 DynamoDB，写入和删除工具验证它们接收到的 PartiQL 语句。读取工具拒绝包含突变动词的语句。写入工具拒绝看起来像批量删除的语句。删除工具只接受 DELETE 语句。这确保了风险级别分类在查询层面实际上被强制执行——LLM 无法通过在 PartiQL 中嵌入 INSERT 来绕过 `dynamo__execute_query` 权限。
+
+对于 MongoDB，连接字符串构建验证认证配置并从连接配置而不是 LLM 提供的参数中强制执行 TLS 设置。
+
+## 输出信封
+
+当工具成功执行时，结果在进入任何地方之前被包装在 `ToolEnvelope` 中：
+
+```
+ToolEnvelope {
+  summary:      结果的前约 1,000 个字符
+  full_result:  截断到约 32,000 个字符的结果
+  metadata: {
+    tool_name,
+    duration_ms,
+    truncated: bool
+  }
+}
+```
+
+信封服务于有不同需求的两个受众。LLM 看到摘要——足够了解发生了什么并决定下一步做什么，但有大小限制以避免单个工具结果消耗整个上下文窗口。用户（通过 UI）可以请求 `full_result` 来检查完整输出。
+
+`truncated` 标志在 UI 中呈现，让用户知道他们看到的是部分结果。如果他们需要完整数据，可以直接在编辑器中重新运行查询。
+
+这种双层输出设计是系统中最实用的决策之一。没有它，返回大型数据集的工具可能在单个步骤中消耗大部分上下文窗口，为对话的其余部分留下不足的空间。有了它，即使在操作大型索引时，Agent 也能保持功能正常。
+
+## 这对你自己的 Agent 意味着什么
+
+这里的模式组合成一个连贯的安全模型：
+
+工具被定义为数据而不是分散在代码库中的代码，意味着系统的安全属性是可审计的。你可以查看工具目录，立即了解 Agent 能做什么和不能做什么。
+
+三道明确的关卡——允许列表、权限检查、用户确认——创造了纵深防御。任何单一关卡的失败（权限配置错误、UI 漏洞、策略疏忽）都不会绕过其他关卡。
+
+执行器抽象将危险代码——实际的数据库调用——与触发它的编排逻辑隔离，并使其可独立测试。
+
+本系列的第三篇将深入确认系统：前端确认 UI 如何与后端的 oneshot 通道交互，会话级权限模式如何工作，以及"始终允许"和"始终拒绝"规则如何让用户随时间建立对 Agent 的信任，而不完全禁用安全检查。
+
+---
+
+*工具注册表在 [`src-tauri/src/agent/tools.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/tools.rs) 中。执行器在 [`src-tauri/src/agent/executor.rs`](https://github.com/geek-fun/dockit/blob/master/src-tauri/src/agent/executor.rs) 中。*


### PR DESCRIPTION
## Summary

A 5-part blog series on building production AI agents, grounded in DocKit's real source code from [PR #440](https://github.com/geek-fun/dockit/pull/440). Each post is published in both English and Chinese.

## Posts

| Part | Title | EN | ZH |
|------|-------|----|----|
| 1 | Architecture | `/blog/building-ai-agent-architecture` | `/zh/blog/building-ai-agent-architecture` |
| 2 | Tool System Design | `/blog/building-ai-agent-tools` | `/zh/blog/building-ai-agent-tools` |
| 3 | Permissions & Confirmation | `/blog/building-ai-agent-permissions` | `/zh/blog/building-ai-agent-permissions` |
| 4 | Memory & Context Compaction | `/blog/building-ai-agent-memory` | `/zh/blog/building-ai-agent-memory` |
| 5 | Persistence & Resilience | `/blog/building-ai-agent-persistence` | `/zh/blog/building-ai-agent-persistence` |

## Changes

- 10 new blog post files (5 EN + 5 ZH)
- Blog index updated for both locales (Part 1 entry at top)
- Full VitePress frontmatter: JSON-LD, canonical, hreflang en/zh/x-default, keywords, datePublished

## Commits

- `cfd403d` content: add 5-part AI agent engineering series (EN)
- `cf0aaa7` content: add 5-part AI agent engineering series (ZH)
- `b3e1b52` content: add AI agent series entry to blog index (EN+ZH)