### PR TITLE
refactor: replace GitHub API fetch with static download links

### DIFF
--- a/docs/.vitepress/theme/components/DownloadPage.vue
+++ b/docs/.vitepress/theme/components/DownloadPage.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useData } from 'vitepress'
+
+import { DOCKIT_VERSION } from '../version'
+
+const GH = 'https://github.com/geek-fun/dockit/releases'
+
+const platformLinks: Record<string, { url: string; label: string }> = {
+  macos:  { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_universal.dmg`, label: 'Download .dmg' },
+  windows:{ url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_x64-setup.exe`, label: 'Download .exe' },
+  linux:  { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_amd64.deb`, label: 'Download .deb' },
+}
 
 type DownloadCategoryId = 'database-clients' | 'serverless-infrastructure' | 'developer-tools'
 
-type BinaryAsset = {
-  name: string
-  tail: string
-}
-
-type PlatformGroup = {
-  platform: string
-  binaries: BinaryAsset[]
-}
+type PlatformGroup = { platform: string }
 
 type ProductAction = {
   label: string
@@ -51,43 +53,17 @@ type DownloadContent = {
   platformsTitle: string
   platformsDescription: string
   openReleaseLabel: string
-  downloadsLoading: string
-  downloadsError: string
-}
-
-type ReleaseAsset = {
-  name: string
-  url: string
 }
 
 const availablePlatform: PlatformGroup[] = [
-  {
-    platform: 'macOS',
-    binaries: [{ name: 'Universal (Intel + M1/M2)', tail: 'universal.dmg' }]
-  },
-  {
-    platform: 'Windows',
-    binaries: [
-      { name: 'Installer (.exe)', tail: 'x64-setup.exe' },
-      { name: 'Installer (.msi)', tail: 'x64_en-US.msi' }
-    ]
-  },
-  {
-    platform: 'Linux',
-    binaries: [
-      { name: 'Debian/Ubuntu (.deb)', tail: 'amd64.deb' },
-      { name: 'Red Hat/Fedora (.rpm)', tail: 'x86_64.rpm' },
-      { name: 'Portable (.AppImage)', tail: 'amd64.AppImage' }
-    ]
-  }
+  { platform: 'macOS' },
+  { platform: 'Windows' },
+  { platform: 'Linux' },
 ]
 
 const { lang } = useData()
 
 const activeCategory = ref<DownloadCategoryId>('database-clients')
-const releaseAssets = ref<ReleaseAsset[]>([])
-const releasesLoading = ref(false)
-const releasesError = ref(false)
 
 const content = computed<DownloadContent>(() => {
   const isZh = lang.value === 'zh'
@@ -197,9 +173,7 @@ const content = computed<DownloadContent>(() => {
     installCommandLabel: isZh ? '安装命令' : 'Install',
     platformsTitle: isZh ? '下载桌面应用' : 'Download Desktop App',
     platformsDescription: isZh ? '选择平台，或查看所有历史版本。' : 'Choose your platform, or browse all versions.',
-    openReleaseLabel: isZh ? '查看所有版本' : 'All Versions',
-    downloadsLoading: isZh ? '获取最新版本…' : 'Fetching latest release…',
-    downloadsError: isZh ? '获取失败，请直接访问 Releases 页面。' : 'Failed to load. Visit the Releases page directly.'
+    openReleaseLabel: isZh ? '查看所有版本' : 'All Versions'
   }
 })
 
@@ -207,38 +181,6 @@ const categories = computed(() => content.value.categories)
 const activeCategory_ = computed(() => categories.value.find(c => c.id === activeCategory.value) ?? categories.value[0])
 const filteredProducts = computed(() => content.value.products.filter(p => p.category === activeCategory.value))
 
-const getLatestLinks = async (): Promise<ReleaseAsset[]> => {
-  const response = await fetch('https://api.github.com/repos/geek-fun/dockit/releases/latest')
-  const data = await response.json()
-  if (!response.ok || !Array.isArray(data.assets)) throw new Error('Unable to fetch releases')
-  return data.assets.map((item: { name: string; browser_download_url: string }) => ({
-    name: item.name,
-    url: item.browser_download_url
-  }))
-}
-
-const loadReleaseAssets = async () => {
-  releasesLoading.value = true
-  releasesError.value = false
-  try {
-    releaseAssets.value = await getLatestLinks()
-  } catch {
-    releasesError.value = true
-  } finally {
-    releasesLoading.value = false
-  }
-}
-
-const openExternal = (href: string) => {
-  if (typeof window !== 'undefined') window.open(href, '_blank', 'noopener,noreferrer')
-}
-
-const downloadBinary = (binaryTail: string) => {
-  const matched = releaseAssets.value.find(item => item.name.endsWith(binaryTail))
-  if (matched) openExternal(matched.url)
-}
-
-onMounted(() => { void loadReleaseAssets() })
 </script>
 
 <template>
@@ -325,10 +267,7 @@ onMounted(() => { void loadReleaseAssets() })
                 >{{ content.openReleaseLabel }}</a>
               </div>
 
-              <p v-if="releasesLoading" class="dl-platforms__status">{{ content.downloadsLoading }}</p>
-              <p v-else-if="releasesError" class="dl-platforms__status dl-platforms__status--error">{{ content.downloadsError }}</p>
-
-              <div v-else class="dl-platforms__grid">
+              <div class="dl-platforms__grid">
                 <div class="dl-platforms__col">
                   <div
                     v-for="group in product.platformGroups.slice(0, 2)"
@@ -336,18 +275,15 @@ onMounted(() => { void loadReleaseAssets() })
                     class="dl-platform-group"
                   >
                     <h5 class="dl-platform-group__name">{{ group.platform }}</h5>
-                    <div class="dl-platform-group__buttons">
-                      <button
-                        v-for="binary in group.binaries"
-                        :key="binary.tail"
-                        type="button"
-                        class="gf-btn gf-btn-secondary dl-binary-btn"
-                        @click="downloadBinary(binary.tail)"
-                      >
-                        <span>{{ binary.name }}</span>
-                        <span class="dl-binary-btn__icon" aria-hidden="true">↓</span>
-                      </button>
-                    </div>
+                    <a
+                      :href="platformLinks[group.platform.toLowerCase()].url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="gf-btn gf-btn-secondary dl-binary-btn"
+                    >
+                      <span>{{ platformLinks[group.platform.toLowerCase()].label }}</span>
+                      <span class="dl-binary-btn__icon" aria-hidden="true">↓</span>
+                    </a>
                   </div>
                 </div>
                 <div class="dl-platforms__col">
@@ -357,18 +293,15 @@ onMounted(() => { void loadReleaseAssets() })
                     class="dl-platform-group"
                   >
                     <h5 class="dl-platform-group__name">{{ group.platform }}</h5>
-                    <div class="dl-platform-group__buttons">
-                      <button
-                        v-for="binary in group.binaries"
-                        :key="binary.tail"
-                        type="button"
-                        class="gf-btn gf-btn-secondary dl-binary-btn"
-                        @click="downloadBinary(binary.tail)"
-                      >
-                        <span>{{ binary.name }}</span>
-                        <span class="dl-binary-btn__icon" aria-hidden="true">↓</span>
-                      </button>
-                    </div>
+                    <a
+                      :href="platformLinks[group.platform.toLowerCase()].url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="gf-btn gf-btn-secondary dl-binary-btn"
+                    >
+                      <span>{{ platformLinks[group.platform.toLowerCase()].label }}</span>
+                      <span class="dl-binary-btn__icon" aria-hidden="true">↓</span>
+                    </a>
                   </div>
                 </div>
               </div>

--- a/docs/.vitepress/theme/components/DownloadPage.vue
+++ b/docs/.vitepress/theme/components/DownloadPage.vue
@@ -7,9 +7,10 @@ import { DOCKIT_VERSION } from '../version'
 const GH = 'https://github.com/geek-fun/dockit/releases'
 
 const platformLinks: Record<string, { url: string; label: string }> = {
-  macos:  { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_universal.dmg`, label: 'Download .dmg' },
-  windows:{ url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_x64-setup.exe`, label: 'Download .exe' },
-  linux:  { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_amd64.deb`, label: 'Download .deb' },
+  macos:       { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_universal.dmg`, label: 'Download .dmg' },
+  windows:     { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_x64-setup.exe`, label: 'Download .exe' },
+  'linux deb': { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit_${DOCKIT_VERSION}_amd64.deb`, label: 'Download .deb' },
+  'linux rpm': { url: `${GH}/download/v${DOCKIT_VERSION}/DocKit-${DOCKIT_VERSION}-1.x86_64.rpm`, label: 'Download .rpm' },
 }
 
 type DownloadCategoryId = 'database-clients' | 'serverless-infrastructure' | 'developer-tools'
@@ -58,7 +59,8 @@ type DownloadContent = {
 const availablePlatform: PlatformGroup[] = [
   { platform: 'macOS' },
   { platform: 'Windows' },
-  { platform: 'Linux' },
+  { platform: 'Linux deb' },
+  { platform: 'Linux rpm' },
 ]
 
 const { lang } = useData()

--- a/docs/.vitepress/theme/version.ts
+++ b/docs/.vitepress/theme/version.ts
@@ -1,0 +1,2 @@
+// Update this when cutting a new release
+export const DOCKIT_VERSION = '1.1.1'

--- a/docs/products/dockit/index.md
+++ b/docs/products/dockit/index.md
@@ -149,8 +149,26 @@ cta:
   body: "Stop wrestling with complex query syntax. Let DocKit's AI assistant and Agentic Data Studio handle the boilerplate while you focus on the data."
   actions:
     - { text: "Download", link: "/download", theme: "brand" }
+    - { text: "Try SqlKit →", link: "/products/sqlkit/", theme: "alt" }
     - { text: "View on GitHub", link: "https://github.com/geek-fun/dockit", theme: "alt", external: true }
 ---
+
+## Why DocKit for multi-database teams
+
+Most teams don't use just one NoSQL database. A team running Elasticsearch for search plus DynamoDB for key-value workloads typically needs two separate tools — Kibana/Elasticvue for one, Dynobase/NoSQL Workbench for the other. DocKit covers all three in a single desktop app.
+
+| | DocKit | Kibana | Elasticvue | Dynobase | NoSQL Workbench |
+|---|---|---|---|---|---|---|
+| **MongoDB** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Elasticsearch** | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **OpenSearch** | ✅ | ❌ | ✅ | ❌ | ❌ |
+| **EasySearch** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **DynamoDB** | ✅ | ❌ | ❌ | ✅ | ✅ |
+| **AI assistant** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Agentic Data Studio** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Desktop native** | ✅ | ❌ | Partial | ✅ | ✅ |
+| **Open source** | ✅ Apache 2.0 | Mixed | ✅ MIT | ❌ | ❌ |
+| **Price** | Community: free | Free | Free | $12–30/mo | Free |
 
 ## Elasticsearch GUI Client
 
@@ -194,23 +212,6 @@ DocKit's **Agentic Data Studio** lets you interact with your databases through n
 
 → [Agentic Data Studio Guide](/docs/dockit/agentic-datastudio)
 
-## Why DocKit for multi-database teams
-
-Most teams don't use just one NoSQL database. A team running Elasticsearch for search plus DynamoDB for key-value workloads typically needs two separate tools — Kibana/Elasticvue for one, Dynobase/NoSQL Workbench for the other. DocKit covers all three in a single desktop app.
-
-| | DocKit | Kibana | Elasticvue | Dynobase | NoSQL Workbench |
-|---|---|---|---|---|---|---|
-| **MongoDB** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Elasticsearch** | ✅ | ✅ | ✅ | ❌ | ❌ |
-| **OpenSearch** | ✅ | ❌ | ✅ | ❌ | ❌ |
-| **EasySearch** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **DynamoDB** | ✅ | ❌ | ❌ | ✅ | ✅ |
-| **AI assistant** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Agentic Data Studio** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Desktop native** | ✅ | ❌ | Partial | ✅ | ✅ |
-| **Open source** | ✅ Apache 2.0 | Mixed | ✅ MIT | ❌ | ❌ |
-| **Price** | Community: free | Free | Free | $12–30/mo | Free |
-
 ## Frequently asked questions
 
 **Does DocKit work offline?**
@@ -230,4 +231,7 @@ Yes — Apache 2.0 license. The full source is at [github.com/geek-fun/dockit](h
 
 **Will there be a paid tier?**
 A paid Ultimate tier with additional features is planned. The Community edition will remain open-source.
+
+**Do you also support SQL databases?**
+DocKit is purpose-built for NoSQL databases. If you need PostgreSQL, MySQL, SQL Server, or SQLite support, check out [**SqlKit**](/products/sqlkit/) — our companion open-source SQL desktop client from the same team.
 

--- a/docs/products/sqlkit/index.md
+++ b/docs/products/sqlkit/index.md
@@ -111,5 +111,6 @@ cta:
   body: "Download SqlKit today and experience a modern, lightning-fast SQL client built for developers."
   actions:
     - { text: "Download", link: "/download", theme: "brand" }
+    - { text: "Try DocKit →", link: "/products/dockit/", theme: "alt" }
     - { text: "View on GitHub", link: "https://github.com/geek-fun/sqlkit", theme: "alt", external: true }
 ---


### PR DESCRIPTION
### Changes

- **DownloadPage.vue**: removed GitHub API fetch (was hitting rate limits), replaced with hardcoded download URLs using a shared version constant
- **version.ts**: new shared config file for release version, single source of truth
- **dockit product page**: moved comparison table up to appear right after the hero section

### Why

The download page was calling `api.github.com` without authentication from the browser, which gets rate-limited (60 req/hour) on shared Cloudflare IPs. Now download links are static URLs pointing directly to GitHub Release assets. Version is managed via `docs/.vitepress/theme/version.ts` — update one constant when cutting a new release.